### PR TITLE
geom_alt props

### DIFF
--- a/data/856/324/83/85632483.geojson
+++ b/data/856/324/83/85632483.geojson
@@ -827,7 +827,9 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "hk-gov"
+        "naturalearth",
+        "hk",
+        "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
@@ -880,6 +882,12 @@
     ],
     "wof:country":"HK",
     "wof:country_alpha3":"HKG",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "hk-gov-reversegeo",
+        "quattroshapes"
+    ],
     "wof:geomhash":"83b9871db5cc9691a8c48dfaf91dd291",
     "wof:hierarchy":[
         {
@@ -897,7 +905,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644435,
+    "wof:lastmodified":1582326408,
     "wof:name":"Hong Kong S.A.R.",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/324/83/85632483.geojson
+++ b/data/856/324/83/85632483.geojson
@@ -827,7 +827,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "hk",
         "quattroshapes"
     ],
@@ -905,7 +904,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1582326408,
+    "wof:lastmodified":1583210156,
     "wof:name":"Hong Kong S.A.R.",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/717/75/85671775.geojson
+++ b/data/856/717/75/85671775.geojson
@@ -236,6 +236,9 @@
         "wd:id":"Q312485"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"806babb83ff1f58214a342f9f167b875",
     "wof:hierarchy":[
         {
@@ -254,7 +257,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644436,
+    "wof:lastmodified":1582326408,
     "wof:name":"Central and Western",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/717/79/85671779.geojson
+++ b/data/856/717/79/85671779.geojson
@@ -188,6 +188,9 @@
         "wd:id":"Q281527"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e956a946c914d25088fa48fa20d94a09",
     "wof:hierarchy":[
         {
@@ -206,7 +209,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644437,
+    "wof:lastmodified":1582326408,
     "wof:name":"Wan Chai",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/717/85/85671785.geojson
+++ b/data/856/717/85/85671785.geojson
@@ -162,6 +162,9 @@
         "qs_pg:id":1263471
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d92e6bda7d4a4d2d8de171693d82c274",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644437,
+    "wof:lastmodified":1582326409,
     "wof:name":"Eastern",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/717/89/85671789.geojson
+++ b/data/856/717/89/85671789.geojson
@@ -170,6 +170,9 @@
         "qs_pg:id":1259511
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cb3bd7d1625b4d6967580bb642769a7",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644436,
+    "wof:lastmodified":1582326408,
     "wof:name":"Southern",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/717/91/85671791.geojson
+++ b/data/856/717/91/85671791.geojson
@@ -142,6 +142,9 @@
         "qs_pg:id":1263472
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f6edc62637aa442897475274b7714b4",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644436,
+    "wof:lastmodified":1582326408,
     "wof:name":"Yau Tsim Mong",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/717/97/85671797.geojson
+++ b/data/856/717/97/85671797.geojson
@@ -222,6 +222,9 @@
         "wd:id":"Q1189342"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a23ef08fc1b3b97f269e34cf4d0cd9aa",
     "wof:hierarchy":[
         {
@@ -240,7 +243,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644437,
+    "wof:lastmodified":1582326408,
     "wof:name":"Kowloon City",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/717/99/85671799.geojson
+++ b/data/856/717/99/85671799.geojson
@@ -171,6 +171,9 @@
         "wd:id":"Q1185317"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"943afc69a892d1eb33ad9630e51350cd",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644437,
+    "wof:lastmodified":1582326408,
     "wof:name":"Sham Shui Po",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/718/05/85671805.geojson
+++ b/data/856/718/05/85671805.geojson
@@ -165,6 +165,9 @@
         "wd:id":"Q2548183"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c32088ec76aa4d376bca90709e82bc9",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644438,
+    "wof:lastmodified":1582326409,
     "wof:name":"Wong Tai Sin",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/718/09/85671809.geojson
+++ b/data/856/718/09/85671809.geojson
@@ -158,6 +158,9 @@
         "wd:id":"Q1045119"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8097f9a89a61b06edef99cc769a880ca",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644439,
+    "wof:lastmodified":1582326409,
     "wof:name":"Kwun Tong",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/718/13/85671813.geojson
+++ b/data/856/718/13/85671813.geojson
@@ -175,6 +175,9 @@
         "wd:id":"Q1753151"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9a9571b282c9f04950183d569da25915",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644440,
+    "wof:lastmodified":1582326410,
     "wof:name":"Sai Kung",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/17/85671817.geojson
+++ b/data/856/718/17/85671817.geojson
@@ -236,6 +236,9 @@
         "wd:id":"Q855463"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9bb5b720c573fa018833aaec0a7a47d",
     "wof:hierarchy":[
         {
@@ -254,7 +257,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644439,
+    "wof:lastmodified":1582326409,
     "wof:name":"Sha Tin",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/23/85671823.geojson
+++ b/data/856/718/23/85671823.geojson
@@ -141,6 +141,9 @@
         "qs_pg:id":221556
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0b0ee9948df09b6e521b21542b96cc1",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644440,
+    "wof:lastmodified":1582326410,
     "wof:name":"Kwai Tsing",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/27/85671827.geojson
+++ b/data/856/718/27/85671827.geojson
@@ -177,6 +177,9 @@
         "wd:id":"Q1758914"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa01c3876fea029c59e9487289ee386a",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644438,
+    "wof:lastmodified":1582326409,
     "wof:name":"Tsuen Wan",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/31/85671831.geojson
+++ b/data/856/718/31/85671831.geojson
@@ -213,6 +213,9 @@
         "wd:id":"Q1758751"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e416ba36b866db2208c422ac3a45558",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644439,
+    "wof:lastmodified":1582326409,
     "wof:name":"Tuen Mun",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/33/85671833.geojson
+++ b/data/856/718/33/85671833.geojson
@@ -159,6 +159,9 @@
         "qs_pg:id":1119649
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c29200dbb06c895d7f69d7a05a9fa85",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644438,
+    "wof:lastmodified":1582326409,
     "wof:name":"Yuen Long",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/39/85671839.geojson
+++ b/data/856/718/39/85671839.geojson
@@ -532,6 +532,9 @@
         "qs_pg:id":579452
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72cb0eff5fb8fdcb3b36e63db2711d31",
     "wof:hierarchy":[
         {
@@ -550,7 +553,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644440,
+    "wof:lastmodified":1582326409,
     "wof:name":"North",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/43/85671843.geojson
+++ b/data/856/718/43/85671843.geojson
@@ -167,6 +167,9 @@
         "wd:id":"Q1758870"
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"12df037f525f79ad2a5fe891da8a9af6",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644439,
+    "wof:lastmodified":1582326409,
     "wof:name":"Tai Po",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/47/85671847.geojson
+++ b/data/856/718/47/85671847.geojson
@@ -144,6 +144,9 @@
         "qs_pg:id":223958
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a49ce876f2cacacf877c848892a2ab41",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644440,
+    "wof:lastmodified":1582326410,
     "wof:name":"Islands",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/859/080/27/85908027.geojson
+++ b/data/859/080/27/85908027.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":977459
     },
     "wof:country":"HK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b49a197081c5ba9c614d168112bcad8e",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "chi"
     ],
-    "wof:lastmodified":1566644435,
+    "wof:lastmodified":1582326408,
     "wof:name":"\u535a\u6276\u6797",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.