### PR TITLE
Name updates

### DIFF
--- a/data/136/069/153/1/1360691531.geojson
+++ b/data/136/069/153/1/1360691531.geojson
@@ -21,7 +21,7 @@
         "Hong Kong International Airport"
     ],
     "name:eng_x_variant":[
-        "Kai Tak International Airport "
+        "Kai Tak International Airport"
     ],
     "src:geom":"sfomuseum",
     "wof:belongsto":[
@@ -46,7 +46,7 @@
         }
     ],
     "wof:id":1360691531,
-    "wof:lastmodified":1539999175,
+    "wof:lastmodified":1587163122,
     "wof:name":"Hong Kong International Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/856/324/83/85632483.geojson
+++ b/data/856/324/83/85632483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095433,
-    "geom:area_square_m":1091156782.388625,
+    "geom:area_square_m":1091157446.344381,
     "geom:bbox":"113.832779,22.151972,114.441254,22.561907",
     "geom:latitude":22.381131,
     "geom:longitude":114.135572,
@@ -169,6 +169,12 @@
     "name:dan_x_preferred":[
         "Hongkong"
     ],
+    "name:deu_at_x_preferred":[
+        "Hongkong"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Hongkong"
+    ],
     "name:deu_x_preferred":[
         "Hongkong"
     ],
@@ -186,6 +192,12 @@
     ],
     "name:ell_x_preferred":[
         "\u03a7\u03bf\u03bd\u03b3\u03ba \u039a\u03bf\u03bd\u03b3\u03ba"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Hong Kong"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Hong Kong"
     ],
     "name:eng_x_preferred":[
         "Hong Kong S.A.R."
@@ -241,6 +253,9 @@
     "name:fra_x_preferred":[
         "Hong Kong"
     ],
+    "name:frr_x_preferred":[
+        "Hongkong"
+    ],
     "name:fry_x_preferred":[
         "Hongkong"
     ],
@@ -250,6 +265,9 @@
     "name:gan_x_preferred":[
         "\u9999\u6e2f"
     ],
+    "name:gcr_x_preferred":[
+        "Hong Kong"
+    ],
     "name:gla_x_preferred":[
         "Hong Kong"
     ],
@@ -258,6 +276,9 @@
     ],
     "name:glg_x_preferred":[
         "Hong Kong"
+    ],
+    "name:got_x_preferred":[
+        "\ud800\udf37\ud800\udf30\ud800\udf3f\ud800\udf32\ud800\udf3a\ud800\udf30\ud800\udf3f\ud800\udf32\ud800\udf32"
     ],
     "name:gsw_x_preferred":[
         "Hongkong"
@@ -467,6 +488,9 @@
     "name:mya_x_preferred":[
         "\u101f\u1031\u102c\u1004\u103a\u1000\u1031\u102c\u1004\u103a"
     ],
+    "name:myv_x_preferred":[
+        "\u0413\u043e\u043d\u043a\u043e\u043d\u0433 \u043e\u0448"
+    ],
     "name:mzn_x_preferred":[
         "\u0647\u0648\u0646\u06af \u06a9\u0648\u0646\u06af"
     ],
@@ -539,6 +563,9 @@
     "name:pol_x_preferred":[
         "Hongkong"
     ],
+    "name:por_br_x_preferred":[
+        "Hong Kong"
+    ],
     "name:por_x_preferred":[
         "Hong Kong"
     ],
@@ -596,6 +623,9 @@
     "name:sme_x_preferred":[
         "Hongkong"
     ],
+    "name:snd_x_preferred":[
+        "\u0647\u0627\u0646\u06af \u06aa\u0627\u0646\u06af"
+    ],
     "name:som_x_preferred":[
         "Hong Kong"
     ],
@@ -628,6 +658,9 @@
     ],
     "name:szl_x_preferred":[
         "H\u016fngk\u016fng"
+    ],
+    "name:szy_x_preferred":[
+        "Hong kong"
     ],
     "name:tam_x_preferred":[
         "\u0bb9\u0bbe\u0b99\u0bcd\u0b95\u0bbe\u0b99\u0bcd"
@@ -905,7 +938,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1583797347,
+    "wof:lastmodified":1587427394,
     "wof:name":"Hong Kong S.A.R.",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.