### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/168/039/421168039.geojson
+++ b/data/421/168/039/421168039.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Yau Tong"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6cb9\u5858"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421168039,
-    "wof:lastmodified":1566644491,
-    "wof:name":"\u6cb9\u5858",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Yau Tong",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/168/039/421168039.geojson
+++ b/data/421/168/039/421168039.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671809,
-        1159397231
+        1159397231,
+        85671809
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421168039,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423072,
     "wof:name":"Yau Tong",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",

--- a/data/421/168/487/421168487.geojson
+++ b/data/421/168/487/421168487.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Wong Ling Bui"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u9ec3\u5dba\u80cc"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421168487,
-    "wof:lastmodified":1566644491,
-    "wof:name":"\u9ec3\u5dba\u80cc",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Wong Ling Bui",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/168/487/421168487.geojson
+++ b/data/421/168/487/421168487.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671839,
-        1159397229
+        1159397229,
+        85671839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421168487,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423064,
     "wof:name":"Wong Ling Bui",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",

--- a/data/421/168/489/421168489.geojson
+++ b/data/421/168/489/421168489.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671833,
-        1159397229
+        1159397229,
+        85671833
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421168489,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423025,
     "wof:name":"Lut Chau",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",

--- a/data/421/168/489/421168489.geojson
+++ b/data/421/168/489/421168489.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Lut Chau"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7529\u6d32"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421168489,
-    "wof:lastmodified":1566644491,
-    "wof:name":"\u7529\u6d32",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Lut Chau",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/170/119/421170119.geojson
+++ b/data/421/170/119/421170119.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Heng Fa Chuen"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u674f\u82b1\u6751"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170119,
-    "wof:lastmodified":1566644524,
-    "wof:name":"\u674f\u82b1\u6751",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Heng Fa Chuen",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/170/119/421170119.geojson
+++ b/data/421/170/119/421170119.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671785,
-        1159397233
+        1159397233,
+        85671785
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170119,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423002,
     "wof:name":"Heng Fa Chuen",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",

--- a/data/421/170/135/421170135.geojson
+++ b/data/421/170/135/421170135.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Stanley Peninsula"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8d64\u67f1\u534a\u5cf6"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170135,
-    "wof:lastmodified":1566644524,
-    "wof:name":"\u8d64\u67f1\u534a\u5cf6",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Stanley Peninsula",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/170/135/421170135.geojson
+++ b/data/421/170/135/421170135.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"114.213352,22.2014705,114.213352,22.2014705",
+    "geom:bbox":"114.213352,22.20147,114.213352,22.20147",
     "geom:latitude":22.20147,
     "geom:longitude":114.213352,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671789,
-        1159397233
+        1159397233,
+        85671789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459008838,
-    "wof:geomhash":"87c618d5641226a0a2925ba3e8184f32",
+    "wof:geomhash":"f72376b3fa6ddd7835c8114f3f5c5e65",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170135,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423054,
     "wof:name":"Stanley Peninsula",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     114.213352,
-    22.2014705,
+    22.20147,
     114.213352,
-    22.2014705
+    22.20147
 ],
-  "geometry": {"coordinates":[114.213352,22.2014705],"type":"Point"}
+  "geometry": {"coordinates":[114.213352,22.20147],"type":"Point"}
 }

--- a/data/421/171/345/421171345.geojson
+++ b/data/421/171/345/421171345.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671817,
-        1159397229
+        1159397229,
+        85671817
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421171345,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423064,
     "wof:name":"Wu Kai Sha",
     "wof:parent_id":85671817,
     "wof:placetype":"locality",

--- a/data/421/171/345/421171345.geojson
+++ b/data/421/171/345/421171345.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Wu Kai Sha"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u70cf\u6eaa\u6c99"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421171345,
-    "wof:lastmodified":1566644534,
-    "wof:name":"\u70cf\u6eaa\u6c99",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Wu Kai Sha",
     "wof:parent_id":85671817,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/171/629/421171629.geojson
+++ b/data/421/171/629/421171629.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tsz Wan Shan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6148\u96f2\u5c71"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421171629,
-    "wof:lastmodified":1566644532,
-    "wof:name":"\u6148\u96f2\u5c71",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Tsz Wan Shan",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/171/629/421171629.geojson
+++ b/data/421/171/629/421171629.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"114.20031,22.3523045,114.20031,22.3523045",
+    "geom:bbox":"114.20031,22.352304,114.20031,22.352304",
     "geom:latitude":22.352304,
     "geom:longitude":114.20031,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671805,
-        1159397231
+        1159397231,
+        85671805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459008901,
-    "wof:geomhash":"b7ae9da930aee7f4f055f596885c0053",
+    "wof:geomhash":"951c0daa07ac97a5a33059fa8c1dc457",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421171629,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423060,
     "wof:name":"Tsz Wan Shan",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     114.20031,
-    22.3523045,
+    22.352304,
     114.20031,
-    22.3523045
+    22.352304
 ],
-  "geometry": {"coordinates":[114.20031,22.3523045],"type":"Point"}
+  "geometry": {"coordinates":[114.20031,22.352304],"type":"Point"}
 }

--- a/data/421/171/631/421171631.geojson
+++ b/data/421/171/631/421171631.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671813,
-        1159397229
+        1159397229,
+        85671813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421171631,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423030,
     "wof:name":"Miu Tsai",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",

--- a/data/421/171/631/421171631.geojson
+++ b/data/421/171/631/421171631.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Miu Tsai"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5edf\u4ed4"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421171631,
-    "wof:lastmodified":1566644533,
-    "wof:name":"\u5edf\u4ed4",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Miu Tsai",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/171/633/421171633.geojson
+++ b/data/421/171/633/421171633.geojson
@@ -17,6 +17,9 @@
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
     "name:eng_x_preferred":[
+        "Islands"
+    ],
+    "name:eng_x_variant":[
         "Islands District"
     ],
     "name:zho_hk_x_preferred":[
@@ -70,8 +73,8 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1601068517,
-    "wof:name":"Islands District",
+    "wof:lastmodified":1601423008,
+    "wof:name":"Islands",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/171/633/421171633.geojson
+++ b/data/421/171/633/421171633.geojson
@@ -16,6 +16,12 @@
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Islands District"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u96e2\u5cf6"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -64,8 +70,8 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644532,
-    "wof:name":"\u96e2\u5cf6",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Islands District",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/171/825/421171825.geojson
+++ b/data/421/171/825/421171825.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671791,
-        1159397231
+        1159397231,
+        85671791
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421171825,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423072,
     "wof:name":"Yau Ma Tei",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",

--- a/data/421/171/825/421171825.geojson
+++ b/data/421/171/825/421171825.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Yau Ma Tei"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6cb9\u9ebb\u5730"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421171825,
-    "wof:lastmodified":1566644533,
-    "wof:name":"\u6cb9\u9ebb\u5730",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Yau Ma Tei",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/171/845/421171845.geojson
+++ b/data/421/171/845/421171845.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tai Wo Estate"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u592a\u548c"
+    ],
     "name:zho_x_preferred":[
         "\u592a\u548c"
     ],
@@ -68,8 +74,8 @@
         }
     ],
     "wof:id":421171845,
-    "wof:lastmodified":1566644532,
-    "wof:name":"\u592a\u548c",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Tai Wo Estate",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/171/845/421171845.geojson
+++ b/data/421/171/845/421171845.geojson
@@ -48,8 +48,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671843,
-        1159397229
+        1159397229,
+        85671843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -74,7 +74,7 @@
         }
     ],
     "wof:id":421171845,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423054,
     "wof:name":"Tai Wo Estate",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",

--- a/data/421/171/931/421171931.geojson
+++ b/data/421/171/931/421171931.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671823,
-        1159397229
+        1159397229,
+        85671823
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421171931,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423045,
     "wof:name":"Sai Tso Wan",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",

--- a/data/421/171/931/421171931.geojson
+++ b/data/421/171/931/421171931.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Sai Tso Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u897f\u9c3d\u7063"
+    ],
     "qs:gn_country":"HK",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1819036,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421171931,
-    "wof:lastmodified":1566644532,
-    "wof:name":"\u897f\u9c3d\u7063",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Sai Tso Wan",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/171/987/421171987.geojson
+++ b/data/421/171/987/421171987.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671789,
-        1159397233
+        1159397233,
+        85671789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421171987,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601422984,
     "wof:name":"Chung Hom Kok",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",

--- a/data/421/171/987/421171987.geojson
+++ b/data/421/171/987/421171987.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Chung Hom Kok"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8202\u574e\u89d2"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421171987,
-    "wof:lastmodified":1566644533,
-    "wof:name":"\u8202\u574e\u89d2",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Chung Hom Kok",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/171/991/421171991.geojson
+++ b/data/421/171/991/421171991.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Cape D'Aguilar"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u9db4\u5480\u534a\u5cf6"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421171991,
-    "wof:lastmodified":1566644532,
-    "wof:name":"\u9db4\u5480\u534a\u5cf6",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Cape D'Aguilar",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/171/991/421171991.geojson
+++ b/data/421/171/991/421171991.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671789,
-        1159397233
+        1159397233,
+        85671789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421171991,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601422981,
     "wof:name":"Cape D'Aguilar",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",

--- a/data/421/174/183/421174183.geojson
+++ b/data/421/174/183/421174183.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671823,
-        1159397229
+        1159397229,
+        85671823
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421174183,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423059,
     "wof:name":"Tsing Leng Tsui",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",

--- a/data/421/174/183/421174183.geojson
+++ b/data/421/174/183/421174183.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tsing Leng Tsui"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u9752\u5dba\u5480"
+    ],
     "qs:gn_country":"HK",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1818491,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421174183,
-    "wof:lastmodified":1566644505,
-    "wof:name":"\u9752\u5dba\u5480",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Tsing Leng Tsui",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/174/847/421174847.geojson
+++ b/data/421/174/847/421174847.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Central Kwai Chung"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u4e2d\u8475\u6d8c"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421174847,
-    "wof:lastmodified":1566644505,
-    "wof:name":"\u4e2d\u8475\u6d8c",
+    "wof:lastmodified":1601068513,
+    "wof:name":"Central Kwai Chung",
     "wof:parent_id":85671827,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/174/847/421174847.geojson
+++ b/data/421/174/847/421174847.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671827,
-        1159397229
+        1159397229,
+        85671827
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421174847,
-    "wof:lastmodified":1601068513,
+    "wof:lastmodified":1601422981,
     "wof:name":"Central Kwai Chung",
     "wof:parent_id":85671827,
     "wof:placetype":"locality",

--- a/data/421/175/139/421175139.geojson
+++ b/data/421/175/139/421175139.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"113.8551715,22.203801,113.8551715,22.203801",
+    "geom:bbox":"113.855171,22.203801,113.855171,22.203801",
     "geom:latitude":22.203801,
     "geom:longitude":113.855171,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459009056,
-    "wof:geomhash":"87029b14c42b892dfb2ec28cb5c2c871",
+    "wof:geomhash":"4d0284e22ad35e7b700121b6e1bf4465",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175139,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601422992,
     "wof:name":"Fan Lau",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    113.8551715,
+    113.855171,
     22.203801,
-    113.8551715,
+    113.855171,
     22.203801
 ],
-  "geometry": {"coordinates":[113.8551715,22.203801],"type":"Point"}
+  "geometry": {"coordinates":[113.855171,22.203801],"type":"Point"}
 }

--- a/data/421/175/139/421175139.geojson
+++ b/data/421/175/139/421175139.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Fan Lau"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5206\u6d41"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175139,
-    "wof:lastmodified":1566644516,
-    "wof:name":"\u5206\u6d41",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Fan Lau",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/329/421175329.geojson
+++ b/data/421/175/329/421175329.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671789,
-        1159397233
+        1159397233,
+        85671789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175329,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423057,
     "wof:name":"The Red Hill",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",

--- a/data/421/175/329/421175329.geojson
+++ b/data/421/175/329/421175329.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "The Red Hill"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7d05\u5c71\u534a\u5cf6"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175329,
-    "wof:lastmodified":1566644516,
-    "wof:name":"\u7d05\u5c71\u534a\u5cf6",
+    "wof:lastmodified":1601068516,
+    "wof:name":"The Red Hill",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/333/421175333.geojson
+++ b/data/421/175/333/421175333.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "So Uk"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8607\u5c4b"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175333,
-    "wof:lastmodified":1566644516,
-    "wof:name":"\u8607\u5c4b",
+    "wof:lastmodified":1601068517,
+    "wof:name":"So Uk",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/333/421175333.geojson
+++ b/data/421/175/333/421175333.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671799,
-        1159397231
+        1159397231,
+        85671799
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175333,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423053,
     "wof:name":"So Uk",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",

--- a/data/421/175/335/421175335.geojson
+++ b/data/421/175/335/421175335.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671805,
-        1159397231
+        1159397231,
+        85671805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175335,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423045,
     "wof:name":"San Po Kong",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",

--- a/data/421/175/335/421175335.geojson
+++ b/data/421/175/335/421175335.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "San Po Kong"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u65b0\u84b2\u5d17"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175335,
-    "wof:lastmodified":1566644516,
-    "wof:name":"\u65b0\u84b2\u5d17",
+    "wof:lastmodified":1601068515,
+    "wof:name":"San Po Kong",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/337/421175337.geojson
+++ b/data/421/175/337/421175337.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Wang Tau Hom"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6a6b\u982d\u78e1"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175337,
-    "wof:lastmodified":1566644514,
-    "wof:name":"\u6a6b\u982d\u78e1",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Wang Tau Hom",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/337/421175337.geojson
+++ b/data/421/175/337/421175337.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671805,
-        1159397231
+        1159397231,
+        85671805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175337,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423061,
     "wof:name":"Wang Tau Hom",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",

--- a/data/421/175/339/421175339.geojson
+++ b/data/421/175/339/421175339.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671805,
-        1159397231
+        1159397231,
+        85671805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175339,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601422989,
     "wof:name":"Diamond Hill",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",

--- a/data/421/175/339/421175339.geojson
+++ b/data/421/175/339/421175339.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Diamond Hill"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u947d\u77f3\u5c71"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175339,
-    "wof:lastmodified":1566644515,
-    "wof:name":"\u947d\u77f3\u5c71",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Diamond Hill",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/341/421175341.geojson
+++ b/data/421/175/341/421175341.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"114.10692,22.4961065,114.10692,22.4961065",
+    "geom:bbox":"114.10692,22.496106,114.10692,22.496106",
     "geom:latitude":22.496106,
     "geom:longitude":114.10692,
     "iso:country":"HK",
@@ -48,8 +48,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671839,
-        1159397229
+        1159397229,
+        85671839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,7 +58,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459009063,
-    "wof:geomhash":"4511c110e475939a9a52418750621ba7",
+    "wof:geomhash":"c77eaefdb0607d75a87fc70d601fd54c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":421175341,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423035,
     "wof:name":"Ngau Tei",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",
@@ -80,9 +80,9 @@
 },
   "bbox": [
     114.10692,
-    22.4961065,
+    22.496106,
     114.10692,
-    22.4961065
+    22.496106
 ],
-  "geometry": {"coordinates":[114.10692,22.4961065],"type":"Point"}
+  "geometry": {"coordinates":[114.10692,22.496106],"type":"Point"}
 }

--- a/data/421/175/341/421175341.geojson
+++ b/data/421/175/341/421175341.geojson
@@ -17,8 +17,14 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Ngau Tei"
+    ],
     "name:jpn_x_preferred":[
         "\u653e\u725b\u5730\u8535"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u725b\u5730"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -63,8 +69,8 @@
         }
     ],
     "wof:id":421175341,
-    "wof:lastmodified":1566644515,
-    "wof:name":"\u725b\u5730",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Ngau Tei",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/343/421175343.geojson
+++ b/data/421/175/343/421175343.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671823,
-        1159397229
+        1159397229,
+        85671823
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175343,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423014,
     "wof:name":"Kam Chuk Kok",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",

--- a/data/421/175/343/421175343.geojson
+++ b/data/421/175/343/421175343.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Kam Chuk Kok"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u91d1\u7af9\u89d2"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175343,
-    "wof:lastmodified":1566644516,
-    "wof:name":"\u91d1\u7af9\u89d2",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Kam Chuk Kok",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/345/421175345.geojson
+++ b/data/421/175/345/421175345.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"113.8923715,22.2795415,113.8923715,22.2795415",
+    "geom:bbox":"113.892371,22.279542,113.892371,22.279542",
     "geom:latitude":22.279542,
     "geom:longitude":113.892371,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459009064,
-    "wof:geomhash":"014bac1755308188c56be33332e3a7e8",
+    "wof:geomhash":"13cce2bd6b229daf4995c8a7e00cfe7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175345,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423047,
     "wof:name":"Sham Shek Tsuen",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    113.89237149999998,
-    22.2795415,
-    113.89237149999998,
-    22.2795415
+    113.892371,
+    22.279542,
+    113.892371,
+    22.279542
 ],
-  "geometry": {"coordinates":[113.89237149999998,22.2795415],"type":"Point"}
+  "geometry": {"coordinates":[113.892371,22.279542],"type":"Point"}
 }

--- a/data/421/175/345/421175345.geojson
+++ b/data/421/175/345/421175345.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Sham Shek Tsuen"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6df1\u77f3\u90a8"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175345,
-    "wof:lastmodified":1566644516,
-    "wof:name":"\u6df1\u77f3\u90a8",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Sham Shek Tsuen",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/355/421175355.geojson
+++ b/data/421/175/355/421175355.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671785,
-        1159397233
+        1159397233,
+        85671785
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175355,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423055,
     "wof:name":"Taikoo Shing",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",

--- a/data/421/175/355/421175355.geojson
+++ b/data/421/175/355/421175355.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Taikoo Shing"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u592a\u53e4\u57ce"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175355,
-    "wof:lastmodified":1566644515,
-    "wof:name":"\u592a\u53e4\u57ce",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Taikoo Shing",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/357/421175357.geojson
+++ b/data/421/175/357/421175357.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671817,
-        1159397229
+        1159397229,
+        85671817
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421175357,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423063,
     "wof:name":"Wonderland",
     "wof:parent_id":85671817,
     "wof:placetype":"locality",

--- a/data/421/175/357/421175357.geojson
+++ b/data/421/175/357/421175357.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Wonderland"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u83ef\u666f"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421175357,
-    "wof:lastmodified":1566644516,
-    "wof:name":"\u83ef\u666f",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Wonderland",
     "wof:parent_id":85671817,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/175/527/421175527.geojson
+++ b/data/421/175/527/421175527.geojson
@@ -70,7 +70,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423035,
     "wof:name":"New Territories",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/421/175/527/421175527.geojson
+++ b/data/421/175/527/421175527.geojson
@@ -16,6 +16,12 @@
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "New Territories"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u65b0\u754c"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -64,8 +70,8 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644515,
-    "wof:name":"\u65b0\u754c",
+    "wof:lastmodified":1601068515,
+    "wof:name":"New Territories",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/176/763/421176763.geojson
+++ b/data/421/176/763/421176763.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"114.22039,22.3344775,114.22039,22.3344775",
+    "geom:bbox":"114.22039,22.334477,114.22039,22.334477",
     "geom:latitude":22.334477,
     "geom:longitude":114.22039,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671805,
-        1159397231
+        1159397231,
+        85671805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459009118,
-    "wof:geomhash":"7276aac41075925205d0ea22a10a6422",
+    "wof:geomhash":"afdafc7564e48a27c3cc0f7395d164dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421176763,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423035,
     "wof:name":"Ngau Chi Wan",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     114.22039,
-    22.3344775,
+    22.334477,
     114.22039,
-    22.3344775
+    22.334477
 ],
-  "geometry": {"coordinates":[114.22038999999999,22.3344775],"type":"Point"}
+  "geometry": {"coordinates":[114.22038999999999,22.334477],"type":"Point"}
 }

--- a/data/421/176/763/421176763.geojson
+++ b/data/421/176/763/421176763.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Ngau Chi Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u725b\u6c60\u7063"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421176763,
-    "wof:lastmodified":1566644530,
-    "wof:name":"\u725b\u6c60\u7063",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Ngau Chi Wan",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/177/247/421177247.geojson
+++ b/data/421/177/247/421177247.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Wang Chau"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6a6b\u6d32"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421177247,
-    "wof:lastmodified":1566644526,
-    "wof:name":"\u6a6b\u6d32",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Wang Chau",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/177/247/421177247.geojson
+++ b/data/421/177/247/421177247.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671833,
-        1159397229
+        1159397229,
+        85671833
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421177247,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423061,
     "wof:name":"Wang Chau",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",

--- a/data/421/177/435/421177435.geojson
+++ b/data/421/177/435/421177435.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671785,
-        1159397233
+        1159397233,
+        85671785
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421177435,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423045,
     "wof:name":"Sai Wan Ho",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",

--- a/data/421/177/435/421177435.geojson
+++ b/data/421/177/435/421177435.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Sai Wan Ho"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u897f\u7063\u6cb3"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421177435,
-    "wof:lastmodified":1566644526,
-    "wof:name":"\u897f\u7063\u6cb3",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Sai Wan Ho",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/179/011/421179011.geojson
+++ b/data/421/179/011/421179011.geojson
@@ -51,8 +51,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671831,
-        1159397229
+        1159397229,
+        85671831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":421179011,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423053,
     "wof:name":"Siu Lam",
     "wof:parent_id":85671831,
     "wof:placetype":"locality",

--- a/data/421/179/011/421179011.geojson
+++ b/data/421/179/011/421179011.geojson
@@ -17,8 +17,14 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Siu Lam"
+    ],
     "name:und_x_variant":[
         "\u5c0f\u6b16"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8403\u7433"
     ],
     "name:zho_x_preferred":[
         "\u5c0f\u6984"
@@ -67,8 +73,8 @@
         }
     ],
     "wof:id":421179011,
-    "wof:lastmodified":1566644528,
-    "wof:name":"\u8403\u7433",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Siu Lam",
     "wof:parent_id":85671831,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/179/199/421179199.geojson
+++ b/data/421/179/199/421179199.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Shap Sze Heung"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5341\u56db\u9109"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421179199,
-    "wof:lastmodified":1566644528,
-    "wof:name":"\u5341\u56db\u9109",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Shap Sze Heung",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/179/199/421179199.geojson
+++ b/data/421/179/199/421179199.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671843,
-        1159397229
+        1159397229,
+        85671843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421179199,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423048,
     "wof:name":"Shap Sze Heung",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",

--- a/data/421/180/075/421180075.geojson
+++ b/data/421/180/075/421180075.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671779,
-        1159397233
+        1159397233,
+        85671779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421180075,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423002,
     "wof:name":"Happy Valley",
     "wof:parent_id":85671779,
     "wof:placetype":"locality",

--- a/data/421/180/075/421180075.geojson
+++ b/data/421/180/075/421180075.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Happy Valley"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8dd1\u99ac\u5730"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421180075,
-    "wof:lastmodified":1566644505,
-    "wof:name":"\u8dd1\u99ac\u5730",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Happy Valley",
     "wof:parent_id":85671779,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/182/077/421182077.geojson
+++ b/data/421/182/077/421182077.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671805,
-        1159397231
+        1159397231,
+        85671805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182077,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423064,
     "wof:name":"Wong Tai Sin",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",

--- a/data/421/182/077/421182077.geojson
+++ b/data/421/182/077/421182077.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Wong Tai Sin"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u9ec3\u5927\u4ed9"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182077,
-    "wof:lastmodified":1566644528,
-    "wof:name":"\u9ec3\u5927\u4ed9",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Wong Tai Sin",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/182/079/421182079.geojson
+++ b/data/421/182/079/421182079.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Jordan Valley"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u4f50\u6566\u8c37"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182079,
-    "wof:lastmodified":1566644528,
-    "wof:name":"\u4f50\u6566\u8c37",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Jordan Valley",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/182/079/421182079.geojson
+++ b/data/421/182/079/421182079.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"114.2202955,22.32068,114.2202955,22.32068",
+    "geom:bbox":"114.220296,22.32068,114.220296,22.32068",
     "geom:latitude":22.32068,
     "geom:longitude":114.220296,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671809,
-        1159397231
+        1159397231,
+        85671809
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459009318,
-    "wof:geomhash":"10261f67931ce729ced271af146e83b9",
+    "wof:geomhash":"e4c4ffc5ea4a5336ef2ef604d7e46b73",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182079,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423013,
     "wof:name":"Jordan Valley",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    114.2202955,
+    114.220296,
     22.32068,
-    114.2202955,
+    114.220296,
     22.32068
 ],
-  "geometry": {"coordinates":[114.22029550000001,22.32068],"type":"Point"}
+  "geometry": {"coordinates":[114.220296,22.32068],"type":"Point"}
 }

--- a/data/421/182/107/421182107.geojson
+++ b/data/421/182/107/421182107.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Sau Mau Ping"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u79c0\u8302\u576a"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182107,
-    "wof:lastmodified":1566644529,
-    "wof:name":"\u79c0\u8302\u576a",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Sau Mau Ping",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/182/107/421182107.geojson
+++ b/data/421/182/107/421182107.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671809,
-        1159397231
+        1159397231,
+        85671809
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182107,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423047,
     "wof:name":"Sau Mau Ping",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",

--- a/data/421/182/155/421182155.geojson
+++ b/data/421/182/155/421182155.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Choi Hung"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5f69\u8679"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182155,
-    "wof:lastmodified":1566644529,
-    "wof:name":"\u5f69\u8679",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Choi Hung",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/182/155/421182155.geojson
+++ b/data/421/182/155/421182155.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671805,
-        1159397231
+        1159397231,
+        85671805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182155,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601422984,
     "wof:name":"Choi Hung",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",

--- a/data/421/182/259/421182259.geojson
+++ b/data/421/182/259/421182259.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671839,
-        1159397229
+        1159397229,
+        85671839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182259,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423052,
     "wof:name":"Shui Lau Hang",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",

--- a/data/421/182/259/421182259.geojson
+++ b/data/421/182/259/421182259.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Shui Lau Hang"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6c34\u6d41\u5751"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182259,
-    "wof:lastmodified":1566644529,
-    "wof:name":"\u6c34\u6d41\u5751",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Shui Lau Hang",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/182/263/421182263.geojson
+++ b/data/421/182/263/421182263.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671817,
-        1159397229
+        1159397229,
+        85671817
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182263,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423047,
     "wof:name":"Sha Tin Heights",
     "wof:parent_id":85671817,
     "wof:placetype":"locality",

--- a/data/421/182/263/421182263.geojson
+++ b/data/421/182/263/421182263.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Sha Tin Heights"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6c99\u7530\u82b1\u5712"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182263,
-    "wof:lastmodified":1566644530,
-    "wof:name":"\u6c99\u7530\u82b1\u5712",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Sha Tin Heights",
     "wof:parent_id":85671817,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/182/265/421182265.geojson
+++ b/data/421/182/265/421182265.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Wok Tai Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u944a\u5e95\u7063"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182265,
-    "wof:lastmodified":1566644530,
-    "wof:name":"\u944a\u5e95\u7063",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Wok Tai Wan",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/182/265/421182265.geojson
+++ b/data/421/182/265/421182265.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671823,
-        1159397229
+        1159397229,
+        85671823
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182265,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423063,
     "wof:name":"Wok Tai Wan",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",

--- a/data/421/182/267/421182267.geojson
+++ b/data/421/182/267/421182267.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Nga Ying Chau"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7259\u9df9\u6d32"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182267,
-    "wof:lastmodified":1566644529,
-    "wof:name":"\u7259\u9df9\u6d32",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Nga Ying Chau",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/182/267/421182267.geojson
+++ b/data/421/182/267/421182267.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671823,
-        1159397229
+        1159397229,
+        85671823
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421182267,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423035,
     "wof:name":"Nga Ying Chau",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",

--- a/data/421/182/835/421182835.geojson
+++ b/data/421/182/835/421182835.geojson
@@ -18,7 +18,7 @@
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
     "name:eng_x_preferred":[
-        "The Peak "
+        "The Peak"
     ],
     "name:zho_hk_x_preferred":[
         "\u5c71\u9802"
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671775,
-        1159397233
+        1159397233,
+        85671775
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,8 +66,8 @@
         }
     ],
     "wof:id":421182835,
-    "wof:lastmodified":1601068515,
-    "wof:name":"The Peak ",
+    "wof:lastmodified":1601423057,
+    "wof:name":"The Peak",
     "wof:parent_id":85671775,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/182/835/421182835.geojson
+++ b/data/421/182/835/421182835.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "The Peak "
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5c71\u9802"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421182835,
-    "wof:lastmodified":1566644529,
-    "wof:name":"\u5c71\u9802",
+    "wof:lastmodified":1601068515,
+    "wof:name":"The Peak ",
     "wof:parent_id":85671775,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/183/045/421183045.geojson
+++ b/data/421/183/045/421183045.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tung Shing Lei"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6771\u6210\u91cc"
+    ],
     "qs:gn_country":"HK",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1818417,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421183045,
-    "wof:lastmodified":1566644527,
-    "wof:name":"\u6771\u6210\u91cc",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Tung Shing Lei",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/183/045/421183045.geojson
+++ b/data/421/183/045/421183045.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671833,
-        1159397229
+        1159397229,
+        85671833
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421183045,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423060,
     "wof:name":"Tung Shing Lei",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",

--- a/data/421/183/333/421183333.geojson
+++ b/data/421/183/333/421183333.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Lung Yeuk Tau"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u9f8d\u8e8d\u982d"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183333,
-    "wof:lastmodified":1566644527,
-    "wof:name":"\u9f8d\u8e8d\u982d",
+    "wof:lastmodified":1601068518,
+    "wof:name":"Lung Yeuk Tau",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/183/333/421183333.geojson
+++ b/data/421/183/333/421183333.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671839,
-        1159397229
+        1159397229,
+        85671839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183333,
-    "wof:lastmodified":1601068518,
+    "wof:lastmodified":1601423025,
     "wof:name":"Lung Yeuk Tau",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",

--- a/data/421/183/787/421183787.geojson
+++ b/data/421/183/787/421183787.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Nam Wah"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5357\u83ef"
+    ],
     "qs:gn_country":"HK",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1819291,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421183787,
-    "wof:lastmodified":1566644527,
-    "wof:name":"\u5357\u83ef",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Nam Wah",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/183/787/421183787.geojson
+++ b/data/421/183/787/421183787.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671813,
-        1159397229
+        1159397229,
+        85671813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421183787,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423032,
     "wof:name":"Nam Wah",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",

--- a/data/421/185/293/421185293.geojson
+++ b/data/421/185/293/421185293.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Sham Shui Po"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6df1\u6c34\u6b65"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185293,
-    "wof:lastmodified":1566644534,
-    "wof:name":"\u6df1\u6c34\u6b65",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Sham Shui Po",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/185/293/421185293.geojson
+++ b/data/421/185/293/421185293.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671799,
-        1159397231
+        1159397231,
+        85671799
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185293,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423047,
     "wof:name":"Sham Shui Po",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",

--- a/data/421/185/433/421185433.geojson
+++ b/data/421/185/433/421185433.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671843,
-        1159397229
+        1159397229,
+        85671843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421185433,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423054,
     "wof:name":"Tai Wo",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",

--- a/data/421/185/433/421185433.geojson
+++ b/data/421/185/433/421185433.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tai Wo"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u592a\u548c"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421185433,
-    "wof:lastmodified":1534379333,
-    "wof:name":"\u592a\u548c",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Tai Wo",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/185/463/421185463.geojson
+++ b/data/421/185/463/421185463.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Lok Fu"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6a02\u5bcc"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185463,
-    "wof:lastmodified":1566644534,
-    "wof:name":"\u6a02\u5bcc",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Lok Fu",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/185/463/421185463.geojson
+++ b/data/421/185/463/421185463.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671805,
-        1159397231
+        1159397231,
+        85671805
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185463,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423023,
     "wof:name":"Lok Fu",
     "wof:parent_id":85671805,
     "wof:placetype":"locality",

--- a/data/421/185/487/421185487.geojson
+++ b/data/421/185/487/421185487.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Shui Lo Cho"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6c34\u6f87\u6f15"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185487,
-    "wof:lastmodified":1566644534,
-    "wof:name":"\u6c34\u6f87\u6f15",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Shui Lo Cho",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/185/487/421185487.geojson
+++ b/data/421/185/487/421185487.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185487,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423052,
     "wof:name":"Shui Lo Cho",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/186/379/421186379.geojson
+++ b/data/421/186/379/421186379.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671813,
-        1159397229
+        1159397229,
+        85671813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186379,
-    "wof:lastmodified":1601068513,
+    "wof:lastmodified":1601423000,
     "wof:name":"Ha Shan Tuk",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",

--- a/data/421/186/379/421186379.geojson
+++ b/data/421/186/379/421186379.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Ha Shan Tuk"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u4e0b\u5c71\u7be4"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186379,
-    "wof:lastmodified":1566644512,
-    "wof:name":"\u4e0b\u5c71\u7be4",
+    "wof:lastmodified":1601068513,
+    "wof:name":"Ha Shan Tuk",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/187/167/421187167.geojson
+++ b/data/421/187/167/421187167.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tai Shek Hau"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5927\u77f3\u9760"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421187167,
-    "wof:lastmodified":1566644506,
-    "wof:name":"\u5927\u77f3\u9760",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Tai Shek Hau",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/187/167/421187167.geojson
+++ b/data/421/187/167/421187167.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421187167,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423054,
     "wof:name":"Tai Shek Hau",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/187/577/421187577.geojson
+++ b/data/421/187/577/421187577.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Allied Plaza"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u806f\u548c\u5ee3\u5834"
+    ],
     "qs:gn_country":"HK",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1819456,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421187577,
-    "wof:lastmodified":1566644510,
-    "wof:name":"\u806f\u548c\u5ee3\u5834",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Allied Plaza",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/187/577/421187577.geojson
+++ b/data/421/187/577/421187577.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671839,
-        1159397229
+        1159397229,
+        85671839
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421187577,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601422975,
     "wof:name":"Allied Plaza",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",

--- a/data/421/187/613/421187613.geojson
+++ b/data/421/187/613/421187613.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tai She Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5927\u86c7\u7063"
+    ],
     "qs:gn_country":"HK",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1818655,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421187613,
-    "wof:lastmodified":1566644509,
-    "wof:name":"\u5927\u86c7\u7063",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Tai She Wan",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/187/613/421187613.geojson
+++ b/data/421/187/613/421187613.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671813,
-        1159397229
+        1159397229,
+        85671813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421187613,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423054,
     "wof:name":"Tai She Wan",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",

--- a/data/421/187/767/421187767.geojson
+++ b/data/421/187/767/421187767.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Chi Ma Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u829d\u9ebb\u7063"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421187767,
-    "wof:lastmodified":1566644508,
-    "wof:name":"\u829d\u9ebb\u7063",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Chi Ma Wan",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/187/767/421187767.geojson
+++ b/data/421/187/767/421187767.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421187767,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601422983,
     "wof:name":"Chi Ma Wan",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/187/777/421187777.geojson
+++ b/data/421/187/777/421187777.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Jardine's Lookout"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6e23\u7538\u5c71"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421187777,
-    "wof:lastmodified":1566644508,
-    "wof:name":"\u6e23\u7538\u5c71",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Jardine's Lookout",
     "wof:parent_id":85671779,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/187/777/421187777.geojson
+++ b/data/421/187/777/421187777.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671779,
-        1159397233
+        1159397233,
+        85671779
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421187777,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423009,
     "wof:name":"Jardine's Lookout",
     "wof:parent_id":85671779,
     "wof:placetype":"locality",

--- a/data/421/187/779/421187779.geojson
+++ b/data/421/187/779/421187779.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671785,
-        1159397233
+        1159397233,
+        85671785
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421187779,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423053,
     "wof:name":"Siu Sai Wan",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",

--- a/data/421/187/779/421187779.geojson
+++ b/data/421/187/779/421187779.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Siu Sai Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5c0f\u897f\u7063"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421187779,
-    "wof:lastmodified":1566644508,
-    "wof:name":"\u5c0f\u897f\u7063",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Siu Sai Wan",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/187/781/421187781.geojson
+++ b/data/421/187/781/421187781.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421187781,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423032,
     "wof:name":"Nam Tam",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/187/781/421187781.geojson
+++ b/data/421/187/781/421187781.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Nam Tam"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5357\u6f6d"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421187781,
-    "wof:lastmodified":1566644509,
-    "wof:name":"\u5357\u6f6d",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Nam Tam",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/187/783/421187783.geojson
+++ b/data/421/187/783/421187783.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421187783,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423052,
     "wof:name":"Shui Hang",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/187/783/421187783.geojson
+++ b/data/421/187/783/421187783.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Shui Hang"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6c34\u5751"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421187783,
-    "wof:lastmodified":1566644508,
-    "wof:name":"\u6c34\u5751",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Shui Hang",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/187/785/421187785.geojson
+++ b/data/421/187/785/421187785.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"114.1113,22.2266665,114.1113,22.2266665",
+    "geom:bbox":"114.1113,22.226667,114.1113,22.226667",
     "geom:latitude":22.226667,
     "geom:longitude":114.1113,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459009524,
-    "wof:geomhash":"404ebb7bf29b1e305d8bf3e5fd8f45ee",
+    "wof:geomhash":"5be2f6b5d89bfaab78f3adfd99ff0bd1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421187785,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423014,
     "wof:name":"Kam Lo Wan",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     114.1113,
-    22.2266665,
+    22.226667,
     114.1113,
-    22.2266665
+    22.226667
 ],
-  "geometry": {"coordinates":[114.1113,22.2266665],"type":"Point"}
+  "geometry": {"coordinates":[114.1113,22.226667],"type":"Point"}
 }

--- a/data/421/187/785/421187785.geojson
+++ b/data/421/187/785/421187785.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Kam Lo Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8804\u87e7\u7063"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421187785,
-    "wof:lastmodified":1566644508,
-    "wof:name":"\u8804\u87e7\u7063",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Kam Lo Wan",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/188/099/421188099.geojson
+++ b/data/421/188/099/421188099.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671833,
-        1159397229
+        1159397229,
+        85671833
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421188099,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423032,
     "wof:name":"Nam Sang Wai",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",

--- a/data/421/188/099/421188099.geojson
+++ b/data/421/188/099/421188099.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Nam Sang Wai"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5357\u751f\u570d"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421188099,
-    "wof:lastmodified":1566644511,
-    "wof:name":"\u5357\u751f\u570d",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Nam Sang Wai",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/188/101/421188101.geojson
+++ b/data/421/188/101/421188101.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671843,
-        1159397229
+        1159397229,
+        85671843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421188101,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601422993,
     "wof:name":"Fu Tau Sha",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",

--- a/data/421/188/101/421188101.geojson
+++ b/data/421/188/101/421188101.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Fu Tau Sha"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u864e\u982d\u6c99"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421188101,
-    "wof:lastmodified":1566644511,
-    "wof:name":"\u864e\u982d\u6c99",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Fu Tau Sha",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/188/103/421188103.geojson
+++ b/data/421/188/103/421188103.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Ngau Shi Wu"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u725b\u5c4e\u6e56"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421188103,
-    "wof:lastmodified":1566644511,
-    "wof:name":"\u725b\u5c4e\u6e56",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Ngau Shi Wu",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/188/103/421188103.geojson
+++ b/data/421/188/103/421188103.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671813,
-        1159397229
+        1159397229,
+        85671813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421188103,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423035,
     "wof:name":"Ngau Shi Wu",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",

--- a/data/421/188/105/421188105.geojson
+++ b/data/421/188/105/421188105.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671813,
-        1159397229
+        1159397229,
+        85671813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421188105,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423035,
     "wof:name":"Ngam Ha Tong",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",

--- a/data/421/188/105/421188105.geojson
+++ b/data/421/188/105/421188105.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Ngam Ha Tong"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u9826\u4e0b\u5802"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421188105,
-    "wof:lastmodified":1566644511,
-    "wof:name":"\u9826\u4e0b\u5802",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Ngam Ha Tong",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/188/107/421188107.geojson
+++ b/data/421/188/107/421188107.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Shek Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u77f3\u7063"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421188107,
-    "wof:lastmodified":1566644511,
-    "wof:name":"\u77f3\u7063",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Shek Wan",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/188/107/421188107.geojson
+++ b/data/421/188/107/421188107.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671823,
-        1159397229
+        1159397229,
+        85671823
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421188107,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423048,
     "wof:name":"Shek Wan",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",

--- a/data/421/191/025/421191025.geojson
+++ b/data/421/191/025/421191025.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191025,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601422995,
     "wof:name":"Fung Peng Syu",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/191/025/421191025.geojson
+++ b/data/421/191/025/421191025.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Fung Peng Syu"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u9cf3\u5e73\u6a39"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191025,
-    "wof:lastmodified":1566644517,
-    "wof:name":"\u9cf3\u5e73\u6a39",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Fung Peng Syu",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/029/421191029.geojson
+++ b/data/421/191/029/421191029.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":22.463071,
     "geom:longitude":114.1543,
     "iso:country":"HK",
+    "label:eng_x_preferred_longname":[
+        "Kangle Village"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "village"
+    ],
     "lbl:bbox":"114.1343,22.443071,114.1743,22.483071",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -18,6 +24,9 @@
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
     "name:eng_x_preferred":[
+        "Kangle"
+    ],
+    "name:eng_x_variant":[
         "Kangle Village"
     ],
     "name:zho_tw_x_preferred":[
@@ -66,8 +75,8 @@
         }
     ],
     "wof:id":421191029,
-    "wof:lastmodified":1601068545,
-    "wof:name":"Kangle Village",
+    "wof:lastmodified":1601337636,
+    "wof:name":"Kangle",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/029/421191029.geojson
+++ b/data/421/191/029/421191029.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":22.463071,
     "geom:longitude":114.1543,
     "iso:country":"HK",
-    "label:eng_x_preferred_longname":[
-        "Kangle Village"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "village"
-    ],
     "lbl:bbox":"114.1343,22.443071,114.1743,22.483071",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -54,8 +48,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671843,
-        1159397229
+        1159397229,
+        85671843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,7 +69,7 @@
         }
     ],
     "wof:id":421191029,
-    "wof:lastmodified":1601337636,
+    "wof:lastmodified":1601423015,
     "wof:name":"Kangle",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",

--- a/data/421/191/029/421191029.geojson
+++ b/data/421/191/029/421191029.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Kangle Village"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5eb7\u6a02\u6751"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191029,
-    "wof:lastmodified":1566644518,
-    "wof:name":"\u5eb7\u6a02\u6751",
+    "wof:lastmodified":1601068545,
+    "wof:name":"Kangle Village",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/031/421191031.geojson
+++ b/data/421/191/031/421191031.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Mong Tseng Tsuen"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7db2\u4e95\u6751"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191031,
-    "wof:lastmodified":1566644518,
-    "wof:name":"\u7db2\u4e95\u6751",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Mong Tseng Tsuen",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/031/421191031.geojson
+++ b/data/421/191/031/421191031.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671833,
-        1159397229
+        1159397229,
+        85671833
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191031,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423031,
     "wof:name":"Mong Tseng Tsuen",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",

--- a/data/421/191/033/421191033.geojson
+++ b/data/421/191/033/421191033.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"113.9500115,22.440562,113.9500115,22.440562",
+    "geom:bbox":"113.950012,22.440562,113.950012,22.440562",
     "geom:latitude":22.440562,
     "geom:longitude":113.950012,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671833,
-        1159397229
+        1159397229,
+        85671833
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459009677,
-    "wof:geomhash":"c2a23829aece5cd522cb6e2fab4da45a",
+    "wof:geomhash":"8541592a6c9ae545ccac517650331910",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191033,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423040,
     "wof:name":"Pak Nai",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    113.9500115,
+    113.950012,
     22.440562,
-    113.9500115,
+    113.950012,
     22.440562
 ],
-  "geometry": {"coordinates":[113.9500115,22.440562],"type":"Point"}
+  "geometry": {"coordinates":[113.950012,22.440562],"type":"Point"}
 }

--- a/data/421/191/033/421191033.geojson
+++ b/data/421/191/033/421191033.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Pak Nai"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u767d\u6ce5"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191033,
-    "wof:lastmodified":1566644518,
-    "wof:name":"\u767d\u6ce5",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Pak Nai",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/035/421191035.geojson
+++ b/data/421/191/035/421191035.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Pui O San Wai Tsuen"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6fb3\u8c9d\u65b0\u6751"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191035,
-    "wof:lastmodified":1566644518,
-    "wof:name":"\u6fb3\u8c9d\u65b0\u6751",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Pui O San Wai Tsuen",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/035/421191035.geojson
+++ b/data/421/191/035/421191035.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191035,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423041,
     "wof:name":"Pui O San Wai Tsuen",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/191/039/421191039.geojson
+++ b/data/421/191/039/421191039.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671789,
-        1159397233
+        1159397233,
+        85671789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191039,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601422980,
     "wof:name":"Big Wave Bay",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",

--- a/data/421/191/039/421191039.geojson
+++ b/data/421/191/039/421191039.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Big Wave Bay"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5927\u6d6a\u7063"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191039,
-    "wof:lastmodified":1566644518,
-    "wof:name":"\u5927\u6d6a\u7063",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Big Wave Bay",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/041/421191041.geojson
+++ b/data/421/191/041/421191041.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191041,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423054,
     "wof:name":"Tai Shui Hang",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/191/041/421191041.geojson
+++ b/data/421/191/041/421191041.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tai Shui Hang"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5927\u6c34\u5751"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191041,
-    "wof:lastmodified":1566644517,
-    "wof:name":"\u5927\u6c34\u5751",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Tai Shui Hang",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/043/421191043.geojson
+++ b/data/421/191/043/421191043.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Black Point"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7f7e\u89d2"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191043,
-    "wof:lastmodified":1566644518,
-    "wof:name":"\u7f7e\u89d2",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Black Point",
     "wof:parent_id":85671831,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/043/421191043.geojson
+++ b/data/421/191/043/421191043.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671831,
-        1159397229
+        1159397229,
+        85671831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191043,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601422980,
     "wof:name":"Black Point",
     "wof:parent_id":85671831,
     "wof:placetype":"locality",

--- a/data/421/191/047/421191047.geojson
+++ b/data/421/191/047/421191047.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671789,
-        1159397233
+        1159397233,
+        85671789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191047,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423059,
     "wof:name":"Tsim Sha Tsui",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",

--- a/data/421/191/047/421191047.geojson
+++ b/data/421/191/047/421191047.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tsim Sha Tsui"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5c16\u6c99\u5480"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191047,
-    "wof:lastmodified":1566644517,
-    "wof:name":"\u5c16\u6c99\u5480",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Tsim Sha Tsui",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/051/421191051.geojson
+++ b/data/421/191/051/421191051.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671785,
-        1159397233
+        1159397233,
+        85671785
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191051,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601422981,
     "wof:name":"Chai Wan",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",

--- a/data/421/191/051/421191051.geojson
+++ b/data/421/191/051/421191051.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Chai Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u67f4\u7063"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191051,
-    "wof:lastmodified":1566644518,
-    "wof:name":"\u67f4\u7063",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Chai Wan",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/053/421191053.geojson
+++ b/data/421/191/053/421191053.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Ap Lei Chau"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u9d28\u5229\u6d32"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191053,
-    "wof:lastmodified":1566644517,
-    "wof:name":"\u9d28\u5229\u6d32",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Ap Lei Chau",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/053/421191053.geojson
+++ b/data/421/191/053/421191053.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671789,
-        1159397233
+        1159397233,
+        85671789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191053,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601422976,
     "wof:name":"Ap Lei Chau",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",

--- a/data/421/191/055/421191055.geojson
+++ b/data/421/191/055/421191055.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Hung Hom"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7d05\u78e1"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191055,
-    "wof:lastmodified":1566644518,
-    "wof:name":"\u7d05\u78e1",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Hung Hom",
     "wof:parent_id":85671797,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/055/421191055.geojson
+++ b/data/421/191/055/421191055.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671797,
-        1159397231
+        1159397231,
+        85671797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191055,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423007,
     "wof:name":"Hung Hom",
     "wof:parent_id":85671797,
     "wof:placetype":"locality",

--- a/data/421/191/727/421191727.geojson
+++ b/data/421/191/727/421191727.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Kowloon Tong"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u4e5d\u9f8d\u5858"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191727,
-    "wof:lastmodified":1566644518,
-    "wof:name":"\u4e5d\u9f8d\u5858",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Kowloon Tong",
     "wof:parent_id":85671797,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/191/727/421191727.geojson
+++ b/data/421/191/727/421191727.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671797,
-        1159397231
+        1159397231,
+        85671797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191727,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423018,
     "wof:name":"Kowloon Tong",
     "wof:parent_id":85671797,
     "wof:placetype":"locality",

--- a/data/421/194/083/421194083.geojson
+++ b/data/421/194/083/421194083.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Ta Kwu Ling"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6253\u9f13\u5dba"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194083,
-    "wof:lastmodified":1566644494,
-    "wof:name":"\u6253\u9f13\u5dba",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Ta Kwu Ling",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/194/083/421194083.geojson
+++ b/data/421/194/083/421194083.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671813,
-        1159397229
+        1159397229,
+        85671813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194083,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423054,
     "wof:name":"Ta Kwu Ling",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",

--- a/data/421/194/131/421194131.geojson
+++ b/data/421/194/131/421194131.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671799,
-        1159397231
+        1159397231,
+        85671799
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194131,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423072,
     "wof:name":"Yau Yat Chuen",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",

--- a/data/421/194/131/421194131.geojson
+++ b/data/421/194/131/421194131.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Yau Yat Chuen"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u53c8\u4e00\u6751"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194131,
-    "wof:lastmodified":1566644495,
-    "wof:name":"\u53c8\u4e00\u6751",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Yau Yat Chuen",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/194/133/421194133.geojson
+++ b/data/421/194/133/421194133.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tsim Sha Tsui East"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5c16\u6c99\u5480\u6771/ \u5c16\u6771"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194133,
-    "wof:lastmodified":1566644493,
-    "wof:name":"\u5c16\u6c99\u5480\u6771/ \u5c16\u6771",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Tsim Sha Tsui East",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/194/133/421194133.geojson
+++ b/data/421/194/133/421194133.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671791,
-        1159397231
+        1159397231,
+        85671791
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194133,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423059,
     "wof:name":"Tsim Sha Tsui East",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",

--- a/data/421/194/805/421194805.geojson
+++ b/data/421/194/805/421194805.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671809,
-        1159397231
+        1159397231,
+        85671809
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194805,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601422981,
     "wof:name":"Cha Kwo Ling",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",

--- a/data/421/194/805/421194805.geojson
+++ b/data/421/194/805/421194805.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Cha Kwo Ling"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8336\u679c\u5dba"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194805,
-    "wof:lastmodified":1566644494,
-    "wof:name":"\u8336\u679c\u5dba",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Cha Kwo Ling",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/198/633/421198633.geojson
+++ b/data/421/198/633/421198633.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421198633,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601422983,
     "wof:name":"Cheung Chau",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/198/633/421198633.geojson
+++ b/data/421/198/633/421198633.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Cheung Chau"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u9577\u6d32"
+    ],
     "qs:gn_country":"HK",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1819968,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421198633,
-    "wof:lastmodified":1566644517,
-    "wof:name":"\u9577\u6d32",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Cheung Chau",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/199/281/421199281.geojson
+++ b/data/421/199/281/421199281.geojson
@@ -16,6 +16,12 @@
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Hong Kong Island"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6e2f\u5cf6"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -64,8 +70,8 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1566644519,
-    "wof:name":"\u6e2f\u5cf6",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Hong Kong Island",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/199/281/421199281.geojson
+++ b/data/421/199/281/421199281.geojson
@@ -70,7 +70,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423005,
     "wof:name":"Hong Kong Island",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/421/200/619/421200619.geojson
+++ b/data/421/200/619/421200619.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671785,
-        1159397233
+        1159397233,
+        85671785
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200619,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423042,
     "wof:name":"Quarry Bay",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",

--- a/data/421/200/619/421200619.geojson
+++ b/data/421/200/619/421200619.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Quarry Bay"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5074\u9b5a\u6d8c"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200619,
-    "wof:lastmodified":1566644521,
-    "wof:name":"\u5074\u9b5a\u6d8c",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Quarry Bay",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/200/661/421200661.geojson
+++ b/data/421/200/661/421200661.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671799,
-        1159397231
+        1159397231,
+        85671799
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200661,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423020,
     "wof:name":"Lai Chi Kok",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",

--- a/data/421/200/661/421200661.geojson
+++ b/data/421/200/661/421200661.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Lai Chi Kok"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8354\u679d\u89d2"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200661,
-    "wof:lastmodified":1566644521,
-    "wof:name":"\u8354\u679d\u89d2",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Lai Chi Kok",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/200/663/421200663.geojson
+++ b/data/421/200/663/421200663.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Mong Kok"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u65fa\u89d2"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200663,
-    "wof:lastmodified":1566644522,
-    "wof:name":"\u65fa\u89d2",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Mong Kok",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/200/663/421200663.geojson
+++ b/data/421/200/663/421200663.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671791,
-        1159397231
+        1159397231,
+        85671791
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200663,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423031,
     "wof:name":"Mong Kok",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",

--- a/data/421/200/665/421200665.geojson
+++ b/data/421/200/665/421200665.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Ngau Tau Kok"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u725b\u982d\u89d2"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200665,
-    "wof:lastmodified":1566644522,
-    "wof:name":"\u725b\u982d\u89d2",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Ngau Tau Kok",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/200/665/421200665.geojson
+++ b/data/421/200/665/421200665.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671809,
-        1159397231
+        1159397231,
+        85671809
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200665,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423035,
     "wof:name":"Ngau Tau Kok",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",

--- a/data/421/200/667/421200667.geojson
+++ b/data/421/200/667/421200667.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Cheung Lung Tin"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u9577\u9f8d\u7530"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200667,
-    "wof:lastmodified":1566644521,
-    "wof:name":"\u9577\u9f8d\u7530",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Cheung Lung Tin",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/200/667/421200667.geojson
+++ b/data/421/200/667/421200667.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671809,
-        1159397231
+        1159397231,
+        85671809
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200667,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601422983,
     "wof:name":"Cheung Lung Tin",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",

--- a/data/421/200/669/421200669.geojson
+++ b/data/421/200/669/421200669.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tsuen Kam Au"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8343\u9326\u51f9"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200669,
-    "wof:lastmodified":1566644521,
-    "wof:name":"\u8343\u9326\u51f9",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Tsuen Kam Au",
     "wof:parent_id":85671827,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/200/669/421200669.geojson
+++ b/data/421/200/669/421200669.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671827,
-        1159397229
+        1159397229,
+        85671827
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200669,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423060,
     "wof:name":"Tsuen Kam Au",
     "wof:parent_id":85671827,
     "wof:placetype":"locality",

--- a/data/421/200/671/421200671.geojson
+++ b/data/421/200/671/421200671.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Lau Fau Shan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6d41\u6d6e\u5c71"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200671,
-    "wof:lastmodified":1566644522,
-    "wof:name":"\u6d41\u6d6e\u5c71",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Lau Fau Shan",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/200/671/421200671.geojson
+++ b/data/421/200/671/421200671.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671833,
-        1159397229
+        1159397229,
+        85671833
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200671,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423020,
     "wof:name":"Lau Fau Shan",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",

--- a/data/421/200/681/421200681.geojson
+++ b/data/421/200/681/421200681.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671791,
-        1159397231
+        1159397231,
+        85671791
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200681,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423013,
     "wof:name":"Jordan",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",

--- a/data/421/200/681/421200681.geojson
+++ b/data/421/200/681/421200681.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Jordan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u4f50\u6566"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200681,
-    "wof:lastmodified":1566644520,
-    "wof:name":"\u4f50\u6566",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Jordan",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/200/947/421200947.geojson
+++ b/data/421/200/947/421200947.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671789,
-        1159397233
+        1159397233,
+        85671789
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200947,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423041,
     "wof:name":"Pok Fu Lam",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",

--- a/data/421/200/947/421200947.geojson
+++ b/data/421/200/947/421200947.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Pok Fu Lam"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8584\u6276\u6797"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200947,
-    "wof:lastmodified":1566644521,
-    "wof:name":"\u8584\u6276\u6797",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Pok Fu Lam",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/200/949/421200949.geojson
+++ b/data/421/200/949/421200949.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Kwun Tong"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u89c0\u5858"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200949,
-    "wof:lastmodified":1566644521,
-    "wof:name":"\u89c0\u5858",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Kwun Tong",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/200/949/421200949.geojson
+++ b/data/421/200/949/421200949.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671809,
-        1159397231
+        1159397231,
+        85671809
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200949,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423020,
     "wof:name":"Kwun Tong",
     "wof:parent_id":85671809,
     "wof:placetype":"locality",

--- a/data/421/201/535/421201535.geojson
+++ b/data/421/201/535/421201535.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"114.2581815,22.16554,114.2581815,22.16554",
+    "geom:bbox":"114.258182,22.16554,114.258182,22.16554",
     "geom:latitude":22.16554,
     "geom:longitude":114.258182,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459010075,
-    "wof:geomhash":"0ad72dd372572b6ed9cb850b55d4bbaa",
+    "wof:geomhash":"f4a41c03cb1dd1faa877229042ecfcd9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201535,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423040,
     "wof:name":"Pak Lau Tsai",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    114.2581815,
+    114.258182,
     22.16554,
-    114.2581815,
+    114.258182,
     22.16554
 ],
-  "geometry": {"coordinates":[114.25818150000001,22.16554],"type":"Point"}
+  "geometry": {"coordinates":[114.25818200000001,22.16554],"type":"Point"}
 }

--- a/data/421/201/535/421201535.geojson
+++ b/data/421/201/535/421201535.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Pak Lau Tsai"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5317\u6d41\u4ed4"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201535,
-    "wof:lastmodified":1566644522,
-    "wof:name":"\u5317\u6d41\u4ed4",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Pak Lau Tsai",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/201/877/421201877.geojson
+++ b/data/421/201/877/421201877.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Shui Tau"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6c34\u982d"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201877,
-    "wof:lastmodified":1566644523,
-    "wof:name":"\u6c34\u982d",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Shui Tau",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/201/877/421201877.geojson
+++ b/data/421/201/877/421201877.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671833,
-        1159397229
+        1159397229,
+        85671833
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201877,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423052,
     "wof:name":"Shui Tau",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",

--- a/data/421/201/911/421201911.geojson
+++ b/data/421/201/911/421201911.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Shap Pat Heung"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5341\u516b\u9109"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201911,
-    "wof:lastmodified":1566644523,
-    "wof:name":"\u5341\u516b\u9109",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Shap Pat Heung",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/201/911/421201911.geojson
+++ b/data/421/201/911/421201911.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671833,
-        1159397229
+        1159397229,
+        85671833
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201911,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423048,
     "wof:name":"Shap Pat Heung",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",

--- a/data/421/201/913/421201913.geojson
+++ b/data/421/201/913/421201913.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Shau Kei Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7b72\u7b95\u7063"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201913,
-    "wof:lastmodified":1566644523,
-    "wof:name":"\u7b72\u7b95\u7063",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Shau Kei Wan",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/201/913/421201913.geojson
+++ b/data/421/201/913/421201913.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671785,
-        1159397233
+        1159397233,
+        85671785
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201913,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423048,
     "wof:name":"Shau Kei Wan",
     "wof:parent_id":85671785,
     "wof:placetype":"locality",

--- a/data/421/201/915/421201915.geojson
+++ b/data/421/201/915/421201915.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Shek Kip Mei"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u77f3\u5cfd\u5c3e"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201915,
-    "wof:lastmodified":1566644523,
-    "wof:name":"\u77f3\u5cfd\u5c3e",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Shek Kip Mei",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/201/915/421201915.geojson
+++ b/data/421/201/915/421201915.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671799,
-        1159397231
+        1159397231,
+        85671799
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201915,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423048,
     "wof:name":"Shek Kip Mei",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",

--- a/data/421/201/919/421201919.geojson
+++ b/data/421/201/919/421201919.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tai Kok Tsui"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5927\u89d2\u5480"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201919,
-    "wof:lastmodified":1566644523,
-    "wof:name":"\u5927\u89d2\u5480",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Tai Kok Tsui",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/201/919/421201919.geojson
+++ b/data/421/201/919/421201919.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671791,
-        1159397231
+        1159397231,
+        85671791
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201919,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423054,
     "wof:name":"Tai Kok Tsui",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",

--- a/data/421/201/921/421201921.geojson
+++ b/data/421/201/921/421201921.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "To Kwa Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u571f\u74dc\u74b0"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201921,
-    "wof:lastmodified":1566644524,
-    "wof:name":"\u571f\u74dc\u74b0",
+    "wof:lastmodified":1601068514,
+    "wof:name":"To Kwa Wan",
     "wof:parent_id":85671797,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/201/921/421201921.geojson
+++ b/data/421/201/921/421201921.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671797,
-        1159397231
+        1159397231,
+        85671797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201921,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423058,
     "wof:name":"To Kwa Wan",
     "wof:parent_id":85671797,
     "wof:placetype":"locality",

--- a/data/421/202/111/421202111.geojson
+++ b/data/421/202/111/421202111.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671833,
-        1159397229
+        1159397229,
+        85671833
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202111,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423040,
     "wof:name":"Pat Heung",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",

--- a/data/421/202/111/421202111.geojson
+++ b/data/421/202/111/421202111.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Pat Heung"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u516b\u9109"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202111,
-    "wof:lastmodified":1566644502,
-    "wof:name":"\u516b\u9109",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Pat Heung",
     "wof:parent_id":85671833,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/202/265/421202265.geojson
+++ b/data/421/202/265/421202265.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671799,
-        1159397231
+        1159397231,
+        85671799
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202265,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423054,
     "wof:name":"Stonecutters Island",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",

--- a/data/421/202/265/421202265.geojson
+++ b/data/421/202/265/421202265.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Stonecutters Island"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6602\u8239\u6d32"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202265,
-    "wof:lastmodified":1566644503,
-    "wof:name":"\u6602\u8239\u6d32",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Stonecutters Island",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/202/267/421202267.geojson
+++ b/data/421/202/267/421202267.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"114.1755215,22.31858,114.1755215,22.31858",
+    "geom:bbox":"114.175522,22.31858,114.175522,22.31858",
     "geom:latitude":22.31858,
     "geom:longitude":114.175522,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671797,
-        1159397231
+        1159397231,
+        85671797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459010111,
-    "wof:geomhash":"922d4e56960c936f359fd5c15257dd97",
+    "wof:geomhash":"5e52fdadc09c4dbbb6c0042a38e71147",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202267,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423004,
     "wof:name":"Ho Man Tin",
     "wof:parent_id":85671797,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    114.1755215,
+    114.175522,
     22.31858,
-    114.1755215,
+    114.175522,
     22.31858
 ],
-  "geometry": {"coordinates":[114.1755215,22.31858],"type":"Point"}
+  "geometry": {"coordinates":[114.175522,22.31858],"type":"Point"}
 }

--- a/data/421/202/267/421202267.geojson
+++ b/data/421/202/267/421202267.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Ho Man Tin"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u4f55\u6587\u7530"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202267,
-    "wof:lastmodified":1566644502,
-    "wof:name":"\u4f55\u6587\u7530",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Ho Man Tin",
     "wof:parent_id":85671797,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/202/269/421202269.geojson
+++ b/data/421/202/269/421202269.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671797,
-        1159397231
+        1159397231,
+        85671797
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202269,
-    "wof:lastmodified":1601068517,
+    "wof:lastmodified":1601423025,
     "wof:name":"Ma Tau Wai",
     "wof:parent_id":85671797,
     "wof:placetype":"locality",

--- a/data/421/202/269/421202269.geojson
+++ b/data/421/202/269/421202269.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Ma Tau Wai"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u99ac\u982d\u570d"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202269,
-    "wof:lastmodified":1566644502,
-    "wof:name":"\u99ac\u982d\u570d",
+    "wof:lastmodified":1601068517,
+    "wof:name":"Ma Tau Wai",
     "wof:parent_id":85671797,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/202/271/421202271.geojson
+++ b/data/421/202/271/421202271.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Beacon Hill"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7b46\u67b6\u5c71"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202271,
-    "wof:lastmodified":1566644503,
-    "wof:name":"\u7b46\u67b6\u5c71",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Beacon Hill",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/202/271/421202271.geojson
+++ b/data/421/202/271/421202271.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"114.174792,22.3375805,114.174792,22.3375805",
+    "geom:bbox":"114.174792,22.337581,114.174792,22.337581",
     "geom:latitude":22.337581,
     "geom:longitude":114.174792,
     "iso:country":"HK",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671799,
-        1159397231
+        1159397231,
+        85671799
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"HK",
     "wof:created":1459010111,
-    "wof:geomhash":"e15a0fe65039fd4b885cb71567755c7c",
+    "wof:geomhash":"bbd8621199402ad5a59e72fcd43636ab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202271,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601422979,
     "wof:name":"Beacon Hill",
     "wof:parent_id":85671799,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     114.174792,
-    22.3375805,
+    22.337581,
     114.174792,
-    22.3375805
+    22.337581
 ],
-  "geometry": {"coordinates":[114.174792,22.3375805],"type":"Point"}
+  "geometry": {"coordinates":[114.174792,22.337581],"type":"Point"}
 }

--- a/data/421/203/137/421203137.geojson
+++ b/data/421/203/137/421203137.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Nam Wan"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5357\u7063"
+    ],
     "qs:gn_country":"HK",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1819287,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421203137,
-    "wof:lastmodified":1566644501,
-    "wof:name":"\u5357\u7063",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Nam Wan",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/203/137/421203137.geojson
+++ b/data/421/203/137/421203137.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671823,
-        1159397229
+        1159397229,
+        85671823
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421203137,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601423033,
     "wof:name":"Nam Wan",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",

--- a/data/421/203/687/421203687.geojson
+++ b/data/421/203/687/421203687.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671813,
-        1159397229
+        1159397229,
+        85671813
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421203687,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423060,
     "wof:name":"Tsui Lam",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",

--- a/data/421/203/687/421203687.geojson
+++ b/data/421/203/687/421203687.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Tsui Lam"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7fe0\u6797"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421203687,
-    "wof:lastmodified":1566644499,
-    "wof:name":"\u7fe0\u6797",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Tsui Lam",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/203/783/421203783.geojson
+++ b/data/421/203/783/421203783.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671847,
-        1159397229
+        1159397229,
+        85671847
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421203783,
-    "wof:lastmodified":1601068514,
+    "wof:lastmodified":1601422983,
     "wof:name":"Chi Ma Hang",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/203/783/421203783.geojson
+++ b/data/421/203/783/421203783.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Chi Ma Hang"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5176\u9081\u884c"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421203783,
-    "wof:lastmodified":1566644500,
-    "wof:name":"\u5176\u9081\u884c",
+    "wof:lastmodified":1601068514,
+    "wof:name":"Chi Ma Hang",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/203/917/421203917.geojson
+++ b/data/421/203/917/421203917.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671843,
-        1159397229
+        1159397229,
+        85671843
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421203917,
-    "wof:lastmodified":1601068516,
+    "wof:lastmodified":1601423048,
     "wof:name":"Shek Hang",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",

--- a/data/421/203/917/421203917.geojson
+++ b/data/421/203/917/421203917.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Shek Hang"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u77f3\u5751"
+    ],
     "qs:gn_country":"HK",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1818906,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421203917,
-    "wof:lastmodified":1566644501,
-    "wof:name":"\u77f3\u5751",
+    "wof:lastmodified":1601068516,
+    "wof:name":"Shek Hang",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/204/237/421204237.geojson
+++ b/data/421/204/237/421204237.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Mount Davis"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6469\u661f\u5dba"
+    ],
     "qs:gn_country":"HK",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":1819339,
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":421204237,
-    "wof:lastmodified":1566644499,
-    "wof:name":"\u6469\u661f\u5dba",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Mount Davis",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-hk",

--- a/data/421/204/237/421204237.geojson
+++ b/data/421/204/237/421204237.geojson
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":421204237,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423031,
     "wof:name":"Mount Davis",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/205/045/421205045.geojson
+++ b/data/421/205/045/421205045.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632483,
-        85671831,
-        1159397229
+        1159397229,
+        85671831
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421205045,
-    "wof:lastmodified":1601068515,
+    "wof:lastmodified":1601423040,
     "wof:name":"Pillar Point",
     "wof:parent_id":85671831,
     "wof:placetype":"locality",

--- a/data/421/205/045/421205045.geojson
+++ b/data/421/205/045/421205045.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Pillar Point"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u671b\u540e\u77f3"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421205045,
-    "wof:lastmodified":1566644503,
-    "wof:name":"\u671b\u540e\u77f3",
+    "wof:lastmodified":1601068515,
+    "wof:name":"Pillar Point",
     "wof:parent_id":85671831,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-hk",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.