### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/175/055/421175055.geojson
+++ b/data/421/175/055/421175055.geojson
@@ -26,6 +26,9 @@
     "name:nld_x_preferred":[
         "Fo Tan"
     ],
+    "name:rus_x_preferred":[
+        "\u0424\u043e \u0422\u0430\u043d"
+    ],
     "name:yue_x_preferred":[
         "\u706b\u70ad"
     ],
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":421175055,
-    "wof:lastmodified":1566644515,
+    "wof:lastmodified":1690930179,
     "wof:name":"\u706b\u70ad",
     "wof:parent_id":85671817,
     "wof:placetype":"locality",

--- a/data/421/175/435/421175435.geojson
+++ b/data/421/175/435/421175435.geojson
@@ -26,6 +26,9 @@
     "name:eng_x_preferred":[
         "Tsimshatsui"
     ],
+    "name:epo_x_preferred":[
+        "Cim\u015dacuj"
+    ],
     "name:fin_x_preferred":[
         "Tsim Sha Tsui"
     ],
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421175435,
-    "wof:lastmodified":1566644516,
+    "wof:lastmodified":1690930179,
     "wof:name":"\u5c16\u6c99\u5480",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",

--- a/data/421/175/437/421175437.geojson
+++ b/data/421/175/437/421175437.geojson
@@ -84,8 +84,14 @@
     "name:tam_x_preferred":[
         "\u0bae\u0bc8\u0baf\u0bae\u0bcd"
     ],
+    "name:tha_x_preferred":[
+        "\u0e40\u0e0b\u0e19\u0e17\u0e23\u0e31\u0e25"
+    ],
     "name:tur_x_preferred":[
         "Merkez"
+    ],
+    "name:vie_x_preferred":[
+        "Trung Ho\u00e0n"
     ],
     "name:yue_x_preferred":[
         "\u4e2d\u74b0"
@@ -139,7 +145,7 @@
         }
     ],
     "wof:id":421175437,
-    "wof:lastmodified":1566644515,
+    "wof:lastmodified":1690930179,
     "wof:name":"\u4e2d\u74b0",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/176/659/421176659.geojson
+++ b/data/421/176/659/421176659.geojson
@@ -32,6 +32,9 @@
     "name:eus_x_preferred":[
         "Kwai Tsing barrutia"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0637\u0642\u0647 \u06a9\u0648\u0627\u06cc \u062a\u0633\u06cc\u0646\u06af"
+    ],
     "name:fra_x_preferred":[
         "Kwai Tsing"
     ],
@@ -43,6 +46,9 @@
     ],
     "name:hun_x_preferred":[
         "Kvajcheng"
+    ],
+    "name:ind_x_preferred":[
+        "Distrik Kwai Tsing"
     ],
     "name:jpn_x_preferred":[
         "\u8475\u9752\u533a"
@@ -84,7 +90,8 @@
         "\u06a9\u0648\u0627\u0626\u06cc \u0679\u0633\u0646\u06af"
     ],
     "name:urd_x_variant":[
-        "\u06a9\u0648\u0627\u0626\u06cc \u062a\u0633\u0646\u06af \u0636\u0644\u0639"
+        "\u06a9\u0648\u0627\u0626\u06cc \u062a\u0633\u0646\u06af \u0636\u0644\u0639",
+        "\u0636\u0644\u0639 \u06a9\u06be\u0648\u0626\u06cc \u0686\u06be\u0646\u06af"
     ],
     "name:vie_x_preferred":[
         "Qu\u1ef3 Thanh"
@@ -146,7 +153,7 @@
         }
     ],
     "wof:id":421176659,
-    "wof:lastmodified":1636496705,
+    "wof:lastmodified":1690930182,
     "wof:name":"Kwai Tsing",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",

--- a/data/421/176/739/421176739.geojson
+++ b/data/421/176/739/421176739.geojson
@@ -23,6 +23,9 @@
     "name:heb_x_preferred":[
         "\u725b\u6c60\u7063"
     ],
+    "name:jpn_x_preferred":[
+        "\u99ac\u6599\u6c34"
+    ],
     "name:nld_x_preferred":[
         "Ma Liu Shui"
     ],
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":421176739,
-    "wof:lastmodified":1566644530,
+    "wof:lastmodified":1690930182,
     "wof:name":"\u99ac\u6599\u6c34",
     "wof:parent_id":85671817,
     "wof:placetype":"locality",

--- a/data/421/181/485/421181485.geojson
+++ b/data/421/181/485/421181485.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0646\u063a\u0648\u0646\u063a \u0628\u064a\u0646\u063a"
+    ],
     "name:eng_x_preferred":[
         "Ngong Ping"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:pol_x_preferred":[
         "Ngong Ping"
+    ],
+    "name:vie_x_preferred":[
+        "Ngang B\u00ecnh"
     ],
     "name:wuu_x_preferred":[
         "\u6602\u576a"
@@ -90,7 +96,7 @@
         }
     ],
     "wof:id":421181485,
-    "wof:lastmodified":1566644513,
+    "wof:lastmodified":1690930179,
     "wof:name":"\u6602\u576a",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/181/839/421181839.geojson
+++ b/data/421/181/839/421181839.geojson
@@ -35,6 +35,9 @@
     "name:eus_x_preferred":[
         "Yau Tsim Mong barrutia"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0637\u0642\u0647 \u06cc\u0627\u0626\u0648 \u062a\u0633\u06cc\u0645 \u0645\u0648\u0646\u06af"
+    ],
     "name:fra_x_preferred":[
         "Yau Tsim Mong"
     ],
@@ -46,6 +49,9 @@
     ],
     "name:hun_x_preferred":[
         "Jauc\u00edmv\u00f3ng"
+    ],
+    "name:ind_x_preferred":[
+        "Distrik Yau Tsim Mong"
     ],
     "name:jpn_x_preferred":[
         "\u6cb9\u5c16\u65fa\u533a"
@@ -149,7 +155,7 @@
         }
     ],
     "wof:id":421181839,
-    "wof:lastmodified":1636496704,
+    "wof:lastmodified":1690930179,
     "wof:name":"Yau Tsim Mong",
     "wof:parent_id":85671791,
     "wof:placetype":"locality",

--- a/data/421/182/231/421182231.geojson
+++ b/data/421/182/231/421182231.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0646\u063a\u0648\u0646\u063a \u0628\u064a\u0646\u063a"
+    ],
     "name:eng_x_preferred":[
         "Ngong Ping"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:pol_x_preferred":[
         "Ngong Ping"
+    ],
+    "name:vie_x_preferred":[
+        "Ngang B\u00ecnh"
     ],
     "name:wuu_x_preferred":[
         "\u6602\u576a"
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":421182231,
-    "wof:lastmodified":1566644530,
+    "wof:lastmodified":1690930182,
     "wof:name":"\u6602\u576a",
     "wof:parent_id":85671813,
     "wof:placetype":"locality",

--- a/data/421/184/551/421184551.geojson
+++ b/data/421/184/551/421184551.geojson
@@ -16,7 +16,13 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:deu_x_preferred":[
+        "Morrison Hill"
+    ],
     "name:eng_x_preferred":[
+        "Morrison Hill"
+    ],
+    "name:nld_x_preferred":[
         "Morrison Hill"
     ],
     "name:und_x_variant":[
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":421184551,
-    "wof:lastmodified":1566644524,
+    "wof:lastmodified":1690930181,
     "wof:name":"\u6469\u5229\u81e3\u5c71",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/185/125/421185125.geojson
+++ b/data/421/185/125/421185125.geojson
@@ -19,8 +19,14 @@
     "name:eng_x_preferred":[
         "Sai Ying Pun"
     ],
+    "name:gan_x_preferred":[
+        "\u897f\u71df\u76e4"
+    ],
     "name:jpn_x_preferred":[
         "\u897f\u55b6\u76e4"
+    ],
+    "name:kor_x_preferred":[
+        "\uc0ac\uc774\uc789\ud47c"
     ],
     "name:und_x_variant":[
         "Sai Ying Poon"
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":421185125,
-    "wof:lastmodified":1566644535,
+    "wof:lastmodified":1690930183,
     "wof:name":"\u897f\u71df\u76e4",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/186/697/421186697.geojson
+++ b/data/421/186/697/421186697.geojson
@@ -19,6 +19,12 @@
     "name:eng_x_preferred":[
         "Sai Wan"
     ],
+    "name:kor_x_preferred":[
+        "\uc0ac\uc774\uc644"
+    ],
+    "name:nld_x_preferred":[
+        "Sai Wan"
+    ],
     "name:rus_x_preferred":[
         "\u0421\u0430\u0439\u0432\u0430\u043d\u044c"
     ],
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":421186697,
-    "wof:lastmodified":1566644513,
+    "wof:lastmodified":1690930178,
     "wof:name":"\u897f\u74b0",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/187/171/421187171.geojson
+++ b/data/421/187/171/421187171.geojson
@@ -19,6 +19,12 @@
     "name:ara_x_preferred":[
         "\u0648\u0627\u0646 \u062a\u0634\u0627\u064a"
     ],
+    "name:cat_x_preferred":[
+        "Wan Chai"
+    ],
+    "name:deu_x_preferred":[
+        "Wan Chai"
+    ],
     "name:eng_x_preferred":[
         "Wan Chai"
     ],
@@ -26,6 +32,9 @@
         "Wan Chai"
     ],
     "name:ind_x_preferred":[
+        "Wan Chai"
+    ],
+    "name:ita_x_preferred":[
         "Wan Chai"
     ],
     "name:jpn_x_preferred":[
@@ -40,11 +49,20 @@
     "name:lzh_x_preferred":[
         "\u7063\u4ed4"
     ],
+    "name:nld_x_preferred":[
+        "Wan Chai"
+    ],
+    "name:nob_x_preferred":[
+        "Wan Chai"
+    ],
     "name:rus_x_preferred":[
         "\u0412\u0430\u043d\u044c\u0447\u0430\u0439"
     ],
     "name:tam_x_preferred":[
         "\u0bb5\u0b9e\u0bcd\u0b9a\u0bbe\u0baf\u0bcd"
+    ],
+    "name:tur_x_preferred":[
+        "Van \u00c7ay"
     ],
     "name:wuu_x_preferred":[
         "\u6e7e\u4ed4"
@@ -95,7 +113,7 @@
         }
     ],
     "wof:id":421187171,
-    "wof:lastmodified":1566644510,
+    "wof:lastmodified":1690930177,
     "wof:name":"\u7063\u4ed4",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/187/581/421187581.geojson
+++ b/data/421/187/581/421187581.geojson
@@ -20,7 +20,13 @@
     "name:eng_x_preferred":[
         "Nim Shue Wan"
     ],
+    "name:jpn_x_preferred":[
+        "\u7a14\u6a39\u6e7e"
+    ],
     "name:yue_x_preferred":[
+        "\u7a14\u6a39\u7063"
+    ],
+    "name:zho_x_preferred":[
         "\u7a14\u6a39\u7063"
     ],
     "qs:gn_country":"HK",
@@ -68,7 +74,7 @@
         }
     ],
     "wof:id":421187581,
-    "wof:lastmodified":1566644507,
+    "wof:lastmodified":1690930177,
     "wof:name":"\u7a14\u6a39\u7063\u6751",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/187/585/421187585.geojson
+++ b/data/421/187/585/421187585.geojson
@@ -20,6 +20,9 @@
     "name:eng_x_preferred":[
         "Sok Kwu Wan"
     ],
+    "name:jpn_x_preferred":[
+        "\u7d22\u7f5f\u6e7e"
+    ],
     "name:nld_x_preferred":[
         "Sok Kwu Wan"
     ],
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421187585,
-    "wof:lastmodified":1566644509,
+    "wof:lastmodified":1690930177,
     "wof:name":"\u7d22\u7f5f\u7063",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/187/615/421187615.geojson
+++ b/data/421/187/615/421187615.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:arz_x_preferred":[
+        "\u062a\u0633\u064a\u0646\u062c \u0649"
+    ],
     "name:ceb_x_preferred":[
         "Tsing Yi"
     ],
@@ -50,6 +53,9 @@
     "name:pol_x_preferred":[
         "Tsing Yi"
     ],
+    "name:rus_x_preferred":[
+        "\u0426\u0438\u043d\u044a\u0438"
+    ],
     "name:spa_x_preferred":[
         "Tsing Yi"
     ],
@@ -64,6 +70,9 @@
     ],
     "name:vie_x_preferred":[
         "Thanh Y"
+    ],
+    "name:vie_x_variant":[
+        "Thanh"
     ],
     "name:yue_x_preferred":[
         "\u9752\u8863\u5cf6"
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":421187615,
-    "wof:lastmodified":1566644509,
+    "wof:lastmodified":1690930177,
     "wof:name":"\u9752\u8863",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",

--- a/data/421/187/831/421187831.geojson
+++ b/data/421/187/831/421187831.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:cat_x_preferred":[
+        "Tuen Mun"
+    ],
     "name:ceb_x_preferred":[
         "Tuen Mun"
     ],
@@ -32,6 +35,9 @@
     "name:fra_x_preferred":[
         "Tuen Mun"
     ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d0\u05d5\u05df \u05de\u05d0\u05df"
+    ],
     "name:ind_x_preferred":[
         "Tuen Mun"
     ],
@@ -39,6 +45,9 @@
         "\ud230\uba3c"
     ],
     "name:nld_x_preferred":[
+        "Tuen Mun"
+    ],
+    "name:por_x_preferred":[
         "Tuen Mun"
     ],
     "name:srp_x_preferred":[
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":421187831,
-    "wof:lastmodified":1566644509,
+    "wof:lastmodified":1690930177,
     "wof:name":"\u5c6f\u9580",
     "wof:parent_id":85671831,
     "wof:placetype":"locality",

--- a/data/421/187/835/421187835.geojson
+++ b/data/421/187/835/421187835.geojson
@@ -20,11 +20,26 @@
     "name:ceb_x_preferred":[
         "Tai O"
     ],
+    "name:ceb_x_variant":[
+        "Tai"
+    ],
     "name:eng_x_preferred":[
         "Tai O"
     ],
+    "name:eng_x_variant":[
+        "Tai"
+    ],
+    "name:fas_x_preferred":[
+        "\u062a\u0627\u06cc \u0627\u0648"
+    ],
     "name:fra_x_preferred":[
         "Tai O"
+    ],
+    "name:fra_x_variant":[
+        "Tai"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d0\u05d9 \u05d0\u05d5"
     ],
     "name:jpn_x_preferred":[
         "\u5927\u6fb3"
@@ -35,11 +50,17 @@
     "name:nld_x_preferred":[
         "Tai O"
     ],
+    "name:nld_x_variant":[
+        "Tai"
+    ],
     "name:rus_x_preferred":[
         "\u0422\u0430\u0439 \u041e"
     ],
     "name:swe_x_preferred":[
         "Tai O"
+    ],
+    "name:swe_x_variant":[
+        "Tai"
     ],
     "name:und_x_variant":[
         "Tai ho"
@@ -99,7 +120,7 @@
         }
     ],
     "wof:id":421187835,
-    "wof:lastmodified":1566644507,
+    "wof:lastmodified":1690930176,
     "wof:name":"\u5927\u6fb3",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/188/267/421188267.geojson
+++ b/data/421/188/267/421188267.geojson
@@ -29,6 +29,9 @@
     "name:fra_x_preferred":[
         "Kwai Chung"
     ],
+    "name:ind_x_preferred":[
+        "Kwai Chung"
+    ],
     "name:jpn_x_preferred":[
         "\u8475\u6d8c"
     ],
@@ -46,6 +49,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bc1\u0bb5\u0bbe\u0baf\u0bcd \u0b9a\u0bc1\u0b99\u0bcd"
+    ],
+    "name:urd_x_preferred":[
+        "\u06a9\u06be\u0648\u0626\u06cc \u0686\u06be\u0646\u06af"
     ],
     "name:wuu_x_preferred":[
         "\u8475\u6d8c"
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":421188267,
-    "wof:lastmodified":1566644511,
+    "wof:lastmodified":1690930178,
     "wof:name":"\u4e0b\u8475\u6d8c",
     "wof:parent_id":85671823,
     "wof:placetype":"locality",

--- a/data/421/192/507/421192507.geojson
+++ b/data/421/192/507/421192507.geojson
@@ -16,6 +16,9 @@
     "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:cat_x_preferred":[
+        "Causeway Bay"
+    ],
     "name:deu_x_preferred":[
         "Causeway Bay"
     ],
@@ -26,6 +29,9 @@
         "Causeway Bay"
     ],
     "name:fra_x_preferred":[
+        "Causeway Bay"
+    ],
+    "name:ind_x_preferred":[
         "Causeway Bay"
     ],
     "name:jpn_x_preferred":[
@@ -105,7 +111,7 @@
         }
     ],
     "wof:id":421192507,
-    "wof:lastmodified":1566644492,
+    "wof:lastmodified":1690930173,
     "wof:name":"\u9285\u947c\u7063",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/192/517/421192517.geojson
+++ b/data/421/192/517/421192517.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Tai Hang"
     ],
+    "name:nld_x_preferred":[
+        "Tai Hang"
+    ],
     "name:rus_x_preferred":[
         "\u0422\u0430\u0439\u0445\u0430\u043d"
     ],
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421192517,
-    "wof:lastmodified":1566644492,
+    "wof:lastmodified":1690930173,
     "wof:name":"\u5927\u5751",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/193/501/421193501.geojson
+++ b/data/421/193/501/421193501.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Leighton Hill"
     ],
+    "name:nld_x_preferred":[
+        "Leighton Hill"
+    ],
     "name:yue_x_preferred":[
         "\u79ae\u9813\u5c71"
     ],
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":421193501,
-    "wof:lastmodified":1566644496,
+    "wof:lastmodified":1690930175,
     "wof:name":"\u52f5\u5fb7\u5c71",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/194/831/421194831.geojson
+++ b/data/421/194/831/421194831.geojson
@@ -74,6 +74,9 @@
     "name:und_x_variant":[
         "Shekpaiwan"
     ],
+    "name:vie_x_preferred":[
+        "Aberdeen"
+    ],
     "name:yue_x_preferred":[
         "\u9999\u6e2f\u4ed4"
     ],
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421194831,
-    "wof:lastmodified":1566644495,
+    "wof:lastmodified":1690930174,
     "wof:name":"\u9999\u6e2f\u4ed4",
     "wof:parent_id":85671789,
     "wof:placetype":"locality",

--- a/data/421/194/833/421194833.geojson
+++ b/data/421/194/833/421194833.geojson
@@ -32,6 +32,9 @@
     "name:jpn_x_preferred":[
         "\u6c99\u7530\u30cb\u30e5\u30fc\u30bf\u30a6\u30f3"
     ],
+    "name:kor_x_preferred":[
+        "\uc0ac\ud2f4 \uc2e0\uc2dc\uc9c4"
+    ],
     "name:nld_x_preferred":[
         "Sha Tin New Town"
     ],
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":421194833,
-    "wof:lastmodified":1566644494,
+    "wof:lastmodified":1690930174,
     "wof:name":"\u6c99\u7530",
     "wof:parent_id":85671817,
     "wof:placetype":"locality",

--- a/data/421/194/835/421194835.geojson
+++ b/data/421/194/835/421194835.geojson
@@ -26,6 +26,9 @@
     "name:fra_x_preferred":[
         "Tai Po"
     ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d0\u05d9 \u05e4\u05d5"
+    ],
     "name:kor_x_preferred":[
         "\ub2e4\ud478"
     ],
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421194835,
-    "wof:lastmodified":1566644494,
+    "wof:lastmodified":1690930173,
     "wof:name":"\u5927\u57d4",
     "wof:parent_id":85671843,
     "wof:placetype":"locality",

--- a/data/421/194/839/421194839.geojson
+++ b/data/421/194/839/421194839.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062c\u0632\u064a\u0631\u0629 \u062a\u0634\u0643 \u0644\u0627\u0628 \u0643\u0648\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0632\u064a\u0631\u0629 \u062a\u0634\u0643 \u0644\u0627\u0628 \u0643\u0648\u0643"
+    ],
     "name:ast_x_preferred":[
         "Chek Lap Kok"
     ],
@@ -35,11 +38,17 @@
     "name:eng_x_preferred":[
         "Chek Lap Kok"
     ],
+    "name:est_x_preferred":[
+        "Chek Lap Kok"
+    ],
     "name:eus_x_preferred":[
         "Chek Lap Kok"
     ],
     "name:fas_x_preferred":[
         "\u0686\u06a9 \u0644\u067e \u06a9\u0648\u06a9"
+    ],
+    "name:fin_x_preferred":[
+        "Chek Lap Kok"
     ],
     "name:fra_x_preferred":[
         "Chek Lap Kok"
@@ -58,6 +67,9 @@
     ],
     "name:kor_x_preferred":[
         "\uce20\ub840\uc790\uc624 \uc12c"
+    ],
+    "name:kor_x_variant":[
+        "\uccb5\ub78d\ucf55\uc12c"
     ],
     "name:nan_x_preferred":[
         "Chhiah-la\u030dh-kak"
@@ -86,11 +98,20 @@
     "name:swe_x_preferred":[
         "Chek Lap Kok"
     ],
+    "name:tam_x_preferred":[
+        "\u0b9a\u0bc6\u0b95\u0bcd \u0bb2\u0bca\u0baa\u0bcd \u0b95\u0bca\u0b95\u0bcd \u0ba4\u0bc0\u0bb5\u0bc1"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e01\u0e32\u0e30\u0e40\u0e0a\u0e47\u0e04\u0e41\u0e25\u0e1b\u0e01\u0e4a\u0e01"
     ],
     "name:tur_x_preferred":[
         "Chek Lap Kok"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0427\u0435\u043a \u041b\u0430\u043f \u041a\u043e\u043a"
+    ],
+    "name:urd_x_preferred":[
+        "\u0686\u06cc\u06a9 \u0644\u0627\u067e \u06a9\u0648\u06a9"
     ],
     "name:vie_x_preferred":[
         "X\u00edch Li\u1ec7p Gi\u00e1c"
@@ -155,7 +176,7 @@
         }
     ],
     "wof:id":421194839,
-    "wof:lastmodified":1566644495,
+    "wof:lastmodified":1690930174,
     "wof:name":"Chek Lap Kok",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/200/087/421200087.geojson
+++ b/data/421/200/087/421200087.geojson
@@ -31,6 +31,9 @@
     "name:hak_x_preferred":[
         "Admiralty"
     ],
+    "name:ind_x_preferred":[
+        "Admiralty"
+    ],
     "name:jpn_x_preferred":[
         "\u91d1\u9418"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0434\u043c\u0456\u0440\u0430\u043b\u0442\u0435\u0439\u0441\u0442\u0432\u043e"
+    ],
+    "name:vie_x_preferred":[
+        "Kim Chung"
     ],
     "name:yue_x_preferred":[
         "\u91d1\u9418"
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":421200087,
-    "wof:lastmodified":1566644522,
+    "wof:lastmodified":1690930180,
     "wof:name":"\u91d1\u9418",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/200/893/421200893.geojson
+++ b/data/421/200/893/421200893.geojson
@@ -17,10 +17,19 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:deu_x_preferred":[
+        "Fung Hang"
+    ],
     "name:eng_x_preferred":[
         "Fung Hang"
     ],
+    "name:fra_x_preferred":[
+        "Fung Hang"
+    ],
     "name:nld_x_preferred":[
+        "Fung Hang"
+    ],
+    "name:spa_x_preferred":[
         "Fung Hang"
     ],
     "name:yue_x_preferred":[
@@ -78,7 +87,7 @@
         }
     ],
     "wof:id":421200893,
-    "wof:lastmodified":1566644521,
+    "wof:lastmodified":1690930180,
     "wof:name":"\u9cf3\u676d",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",

--- a/data/421/201/481/421201481.geojson
+++ b/data/421/201/481/421201481.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:cat_x_preferred":[
+        "Beijiao"
+    ],
     "name:eng_x_preferred":[
         "North Point"
     ],
@@ -26,11 +29,20 @@
     "name:kor_x_preferred":[
         "\ub178\uc2a4\ud3ec\uc778\ud2b8"
     ],
+    "name:nld_x_preferred":[
+        "North Point"
+    ],
     "name:rus_x_preferred":[
         "\u041d\u043e\u0440\u0442-\u041f\u043e\u0439\u043d\u0442"
     ],
+    "name:ukr_x_preferred":[
+        "\u041d\u043e\u0440\u0442 \u041f\u043e\u0439\u043d\u0442"
+    ],
     "name:und_x_variant":[
         "Pak Kok"
+    ],
+    "name:vie_x_preferred":[
+        "B\u1eafc Gi\u00e1c"
     ],
     "name:yue_x_preferred":[
         "\u5317\u89d2"
@@ -83,7 +95,7 @@
         }
     ],
     "wof:id":421201481,
-    "wof:lastmodified":1566644523,
+    "wof:lastmodified":1690930181,
     "wof:name":"\u5317\u89d2",
     "wof:parent_id":85671831,
     "wof:placetype":"locality",

--- a/data/421/201/525/421201525.geojson
+++ b/data/421/201/525/421201525.geojson
@@ -20,6 +20,9 @@
     "name:eng_x_preferred":[
         "Yung Shue Wan"
     ],
+    "name:jpn_x_preferred":[
+        "\u6995\u6a39\u6e7e"
+    ],
     "name:nld_x_preferred":[
         "Yung Shue Wan"
     ],
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":421201525,
-    "wof:lastmodified":1566644523,
+    "wof:lastmodified":1690930181,
     "wof:name":"\u6995\u6a39\u7063",
     "wof:parent_id":85671847,
     "wof:placetype":"locality",

--- a/data/421/204/403/421204403.geojson
+++ b/data/421/204/403/421204403.geojson
@@ -23,6 +23,9 @@
     "name:nld_x_preferred":[
         "Yung Shue Au"
     ],
+    "name:yue_x_preferred":[
+        "\u6995\u6a39\u51f9"
+    ],
     "name:zho_x_preferred":[
         "\u6995\u6a39\u51f9"
     ],
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":421204403,
-    "wof:lastmodified":1566644499,
+    "wof:lastmodified":1690930175,
     "wof:name":"\u6995\u6a39\u51f9",
     "wof:parent_id":85671839,
     "wof:placetype":"locality",

--- a/data/856/324/83/85632483.geojson
+++ b/data/856/324/83/85632483.geojson
@@ -52,17 +52,29 @@
     "name:aka_x_preferred":[
         "Hong Kong"
     ],
+    "name:alt_x_preferred":[
+        "\u0413\u043e\u043d\u043a\u043e\u043d\u0433"
+    ],
     "name:amh_x_preferred":[
         "\u1206\u1295\u130d \u12ae\u1295\u130d"
     ],
+    "name:ami_x_preferred":[
+        "Hong kong"
+    ],
     "name:ang_x_preferred":[
         "Hong Kong"
+    ],
+    "name:anp_x_preferred":[
+        "\u0939\u093e\u0901\u0917\u0915\u093e\u0901\u0917"
     ],
     "name:ara_x_preferred":[
         "\u0647\u0648\u0646\u063a \u0643\u0648\u0646\u063a"
     ],
     "name:arg_x_preferred":[
         "Hong Kong"
+    ],
+    "name:ary_x_preferred":[
+        "\u0647\u0648\u0646\u0643\u0648\u0646\u06ad"
     ],
     "name:arz_x_preferred":[
         "\u0647\u0648\u0646\u062c \u0643\u0648\u0646\u062c"
@@ -72,6 +84,9 @@
     ],
     "name:ast_x_preferred":[
         "\u1e24ong Kong"
+    ],
+    "name:awa_x_preferred":[
+        "\u0939\u0919\u0915\u0919"
     ],
     "name:azb_x_preferred":[
         "\u0647\u0648\u0646\u06af \u06a9\u0648\u0646\u06af"
@@ -86,6 +101,9 @@
         "\u0413\u043e\u043d\u043a\u043e\u043d\u0433"
     ],
     "name:bam_x_preferred":[
+        "Hong Kong"
+    ],
+    "name:ban_x_preferred":[
         "Hong Kong"
     ],
     "name:bar_x_preferred":[
@@ -127,6 +145,9 @@
     "name:brh_x_preferred":[
         "H\u00e1ng K\u00e1ng"
     ],
+    "name:bug_x_preferred":[
+        "Hong Kong"
+    ],
     "name:bul_x_preferred":[
         "\u0425\u043e\u043d\u043a\u043e\u043d\u0433"
     ],
@@ -148,6 +169,9 @@
     "name:che_x_preferred":[
         "\u0413\u043e\u043d\u043a\u043e\u043d\u0433"
     ],
+    "name:chr_x_preferred":[
+        "\u13b0\u13c2\u13a9 \u13aa\u13c2\u13a9"
+    ],
     "name:chv_x_preferred":[
         "\u0413\u043e\u043d\u043a\u043e\u043d\u0433"
     ],
@@ -160,11 +184,20 @@
     "name:cor_x_preferred":[
         "Hong Kong"
     ],
+    "name:cos_x_preferred":[
+        "Hong Kong"
+    ],
+    "name:crh_x_preferred":[
+        "Ho\u00f1 Ko\u00f1"
+    ],
     "name:cym_x_preferred":[
         "Hong Kong S.A.R., Tseina"
     ],
     "name:cym_x_variant":[
         "Hong Cong"
+    ],
+    "name:dag_x_preferred":[
+        "Hong Kong"
     ],
     "name:dan_x_preferred":[
         "Hongkong"
@@ -259,6 +292,9 @@
     "name:fry_x_preferred":[
         "Hongkong"
     ],
+    "name:fur_x_preferred":[
+        "Hong Kong"
+    ],
     "name:gag_x_preferred":[
         "Hong Kong"
     ],
@@ -277,8 +313,17 @@
     "name:glg_x_preferred":[
         "Hong Kong"
     ],
+    "name:glv_x_preferred":[
+        "Hong Kong"
+    ],
     "name:got_x_preferred":[
         "\ud800\udf37\ud800\udf30\ud800\udf3f\ud800\udf32\ud800\udf3a\ud800\udf30\ud800\udf3f\ud800\udf32\ud800\udf32"
+    ],
+    "name:gpe_x_preferred":[
+        "Hong Kong"
+    ],
+    "name:grn_x_preferred":[
+        "Hong Kong"
     ],
     "name:gsw_x_preferred":[
         "Hongkong"
@@ -296,6 +341,9 @@
         "Hong Kong"
     ],
     "name:hau_x_preferred":[
+        "Hong Kong"
+    ],
+    "name:haw_x_preferred":[
         "Hong Kong"
     ],
     "name:heb_x_preferred":[
@@ -319,14 +367,23 @@
     "name:hye_x_preferred":[
         "\u0540\u0578\u0576\u056f\u0578\u0576\u0563"
     ],
+    "name:hyw_x_preferred":[
+        "\u0540\u0578\u0576\u056f \u0554\u0578\u0576\u056f"
+    ],
     "name:ibo_x_preferred":[
         "Hong Kong"
     ],
     "name:ido_x_preferred":[
         "Hong Kong"
     ],
+    "name:iku_x_preferred":[
+        "\u1473\u1595 \u146d\u1595"
+    ],
     "name:ile_x_preferred":[
         "Hongkong"
+    ],
+    "name:ile_x_variant":[
+        "Hong Kong"
     ],
     "name:ilo_x_preferred":[
         "Hong Kong"
@@ -368,6 +425,9 @@
     "name:kan_x_preferred":[
         "\u0cb9\u0cbe\u0c82\u0c97\u0ccd \u0c95\u0cbe\u0c82\u0c97\u0ccd"
     ],
+    "name:kas_x_preferred":[
+        "\u06c1\u0627\u0646\u06a9 \u06a9\u0627\u0646\u06af"
+    ],
     "name:kat_x_preferred":[
         "\u10f0\u10dd\u10dc\u10d2 \u10d9\u10dd\u10dc\u10d2\u10d8"
     ],
@@ -382,6 +442,9 @@
     ],
     "name:kbp_x_preferred":[
         "H\u0254\u014bk\u0254\u014b"
+    ],
+    "name:kcg_x_preferred":[
+        "Hong Kong"
     ],
     "name:khm_x_preferred":[
         "\u17a0\u17bb\u1784\u1780\u17bb\u1784"
@@ -431,6 +494,9 @@
     "name:lit_x_preferred":[
         "Honkongas"
     ],
+    "name:lld_x_preferred":[
+        "Hong Kong"
+    ],
     "name:lmo_x_preferred":[
         "Hong Kong"
     ],
@@ -442,6 +508,9 @@
     ],
     "name:lzh_x_preferred":[
         "\u9999\u6e2f"
+    ],
+    "name:mad_x_preferred":[
+        "Hong Kong"
     ],
     "name:mai_x_preferred":[
         "\u0939\u0919\u0915\u0919"
@@ -476,6 +545,12 @@
     "name:mlt_x_preferred":[
         "\u0126ong Kong"
     ],
+    "name:mlt_x_variant":[
+        "Hong Kong"
+    ],
+    "name:mni_x_preferred":[
+        "\uabcd\uabe3\uabe1 \uabc0\uabe3\uabe1"
+    ],
     "name:mon_x_preferred":[
         "\u0425\u043e\u043d\u0433 \u041a\u043e\u043d\u0433"
     ],
@@ -503,6 +578,9 @@
     "name:nap_x_preferred":[
         "Hong Kong"
     ],
+    "name:nav_x_preferred":[
+        "Sh\u00e1di\u02bc\u00e1\u00e1hj\u00ed Tsii\u02bcyishbizh\u00ed Bikin Haal\u02bc\u00e1"
+    ],
     "name:nds_x_preferred":[
         "Hongkong"
     ],
@@ -511,6 +589,9 @@
     ],
     "name:new_x_preferred":[
         "\u0939\u0919\u0915\u0919"
+    ],
+    "name:nia_x_preferred":[
+        "Hong Kong"
     ],
     "name:nld_x_preferred":[
         "Hongkong"
@@ -533,6 +614,9 @@
     "name:oci_x_preferred":[
         "Hong Kong"
     ],
+    "name:olo_x_preferred":[
+        "Hong Kong"
+    ],
     "name:ori_x_preferred":[
         "\u0b39\u0b02\u0b15\u0b02 \u0b2c\u0b3f\u0b36\u0b47\u0b37 \u0b2a\u0b4d\u0b30\u0b36\u0b3e\u0b38\u0b28\u0b3f\u0b15 \u0b15\u0b4d\u0b37\u0b47\u0b24\u0b4d\u0b30 \u0b1a\u0b40\u0b28\u0b4d"
     ],
@@ -552,6 +636,9 @@
         "Hong Kong"
     ],
     "name:pcd_x_preferred":[
+        "Hong Kong"
+    ],
+    "name:pih_x_preferred":[
         "Hong Kong"
     ],
     "name:pms_x_preferred":[
@@ -584,6 +671,9 @@
     "name:rue_x_preferred":[
         "\u0413\u043e\u043d\u0491 \u041a\u043e\u043d\u0491"
     ],
+    "name:rup_x_preferred":[
+        "Hongkong"
+    ],
     "name:rus_x_preferred":[
         "\u0413\u043e\u043d\u043a\u043e\u043d\u0433"
     ],
@@ -604,6 +694,9 @@
     ],
     "name:sgs_x_preferred":[
         "Huonkuongs"
+    ],
+    "name:shn_x_preferred":[
+        "\u1081\u103d\u1004\u103a\u1038\u1075\u103d\u1004\u103a\u1038"
     ],
     "name:sin_x_preferred":[
         "\u0dc4\u0ddc\u0d82\u0d9a\u0ddc\u0d82"
@@ -671,6 +764,9 @@
     "name:tat_x_preferred":[
         "\u04ba\u043e\u04a3 \u041a\u043e\u04a3"
     ],
+    "name:tay_x_preferred":[
+        "Hong kong"
+    ],
     "name:tel_x_preferred":[
         "\u0c39\u0c3e\u0c02\u0c17\u0c4d \u0c15\u0c3e\u0c02\u0c17\u0c4d"
     ],
@@ -692,8 +788,17 @@
     "name:tir_x_preferred":[
         "\u1206\u1295\u130d \u12ae\u1295\u130d"
     ],
+    "name:tok_x_preferred":[
+        "ma Enkon"
+    ],
     "name:ton_x_preferred":[
         "Hongi Kongi"
+    ],
+    "name:tpi_x_preferred":[
+        "Hong Kong"
+    ],
+    "name:trv_x_preferred":[
+        "Hong Kong"
     ],
     "name:tsn_x_preferred":[
         "Hong Kong"
@@ -702,6 +807,9 @@
         "Gonkong"
     ],
     "name:tur_x_preferred":[
+        "Hong Kong"
+    ],
+    "name:twi_x_preferred":[
         "Hong Kong"
     ],
     "name:uig_x_preferred":[
@@ -1003,7 +1111,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1617827442,
+    "wof:lastmodified":1690930169,
     "wof:name":"Hong Kong S.A.R.",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/717/75/85671775.geojson
+++ b/data/856/717/75/85671775.geojson
@@ -52,6 +52,9 @@
     "name:epo_x_preferred":[
         "Centrokcidenta Distrikto"
     ],
+    "name:est_x_preferred":[
+        "Kesk- ja L\u00e4\u00e4nepiirkond"
+    ],
     "name:eus_x_preferred":[
         "Erdialde eta mendebaldeko barrutia"
     ],
@@ -70,6 +73,9 @@
     "name:hun_x_preferred":[
         "K\u00f6zponti \u00e9s nyugati ker\u00fclet"
     ],
+    "name:ind_x_preferred":[
+        "Distrik Pusat dan Barat"
+    ],
     "name:ita_x_preferred":[
         "Distretto Centrale e Occidentale"
     ],
@@ -84,6 +90,12 @@
     ],
     "name:kor_x_variant":[
         "\uc911\uc2dc\uad6c"
+    ],
+    "name:lzh_x_preferred":[
+        "\u4e2d\u897f\u5340"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0426\u0435\u043d\u0442\u0440\u0430\u043b\u0435\u043d \u0438 \u0417\u0430\u043f\u0430\u0434\u0435\u043d \u041e\u043a\u0440\u0443\u0433"
     ],
     "name:nan_x_preferred":[
         "Tiong-se-khu"
@@ -111,6 +123,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bae\u0bc8\u0baf\u0bae\u0bcd \u0bae\u0bb1\u0bcd\u0bb1\u0bc1\u0bae\u0bcd \u0bae\u0bc7\u0bb1\u0bcd\u0b95\u0bc1 \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
+    ],
+    "name:tum_x_preferred":[
+        "Pakati na Kumanjiliro gha dazi"
     ],
     "name:tur_x_preferred":[
         "Orta ve Bat\u0131"
@@ -266,7 +281,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496700,
+    "wof:lastmodified":1690930170,
     "wof:name":"Central and Western",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/717/79/85671779.geojson
+++ b/data/856/717/79/85671779.geojson
@@ -31,6 +31,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0627\u0646 \u062a\u0634\u0627\u064a"
     ],
+    "name:cat_x_preferred":[
+        "Wan Chai"
+    ],
     "name:deu_x_preferred":[
         "Wan Chai"
     ],
@@ -47,6 +50,9 @@
         "Wan Chai"
     ],
     "name:ind_x_preferred":[
+        "Wan Chai"
+    ],
+    "name:ita_x_preferred":[
         "Wan Chai"
     ],
     "name:jpn_x_preferred":[
@@ -68,6 +74,9 @@
     "name:nld_x_preferred":[
         "Wan Chai"
     ],
+    "name:nob_x_preferred":[
+        "Wan Chai"
+    ],
     "name:pol_x_preferred":[
         "Wan Chai"
     ],
@@ -85,6 +94,9 @@
     ],
     "name:tur_x_preferred":[
         "Wan Chai"
+    ],
+    "name:tur_x_variant":[
+        "Van \u00c7ay"
     ],
     "name:ukr_x_preferred":[
         "\u0412\u0430\u043d\u0447\u0430\u0456"
@@ -240,7 +252,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496701,
+    "wof:lastmodified":1690930170,
     "wof:name":"Wan Chai",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/717/97/85671797.geojson
+++ b/data/856/717/97/85671797.geojson
@@ -77,6 +77,9 @@
     "name:nld_x_variant":[
         "Kowloon City"
     ],
+    "name:nob_x_preferred":[
+        "Kowloon City"
+    ],
     "name:nor_x_preferred":[
         "Kowloon City"
     ],
@@ -252,7 +255,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496701,
+    "wof:lastmodified":1690930170,
     "wof:name":"Kowloon City",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/717/99/85671799.geojson
+++ b/data/856/717/99/85671799.geojson
@@ -37,6 +37,9 @@
     "name:jpn_x_preferred":[
         "\u6df1\u6c34\u30db"
     ],
+    "name:jpn_x_variant":[
+        "\u6df1\u6c34\u57d7"
+    ],
     "name:kor_x_preferred":[
         "\uc0f4 \uc218\uc774 \ud3ec"
     ],
@@ -223,7 +226,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496701,
+    "wof:lastmodified":1690930170,
     "wof:name":"Sham Shui Po",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/718/05/85671805.geojson
+++ b/data/856/718/05/85671805.geojson
@@ -37,6 +37,9 @@
     "name:fra_x_preferred":[
         "Chuk Un"
     ],
+    "name:fra_x_variant":[
+        "Wong Tai Sin"
+    ],
     "name:jpn_x_preferred":[
         "\u9ec4\u521d\u5e73"
     ],
@@ -222,7 +225,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496702,
+    "wof:lastmodified":1690930171,
     "wof:name":"Wong Tai Sin",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/718/09/85671809.geojson
+++ b/data/856/718/09/85671809.geojson
@@ -31,6 +31,9 @@
     "name:ceb_x_preferred":[
         "Guantang"
     ],
+    "name:deu_x_preferred":[
+        "Kwun Tong"
+    ],
     "name:eng_x_preferred":[
         "Kwun Tong"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:kor_x_variant":[
         "\uad70\ud1b5"
+    ],
+    "name:nob_x_preferred":[
+        "Kwun Tong"
     ],
     "name:swe_x_preferred":[
         "Kwun Tong"
@@ -203,7 +209,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496703,
+    "wof:lastmodified":1690930171,
     "wof:name":"Kwun Tong",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/718/13/85671813.geojson
+++ b/data/856/718/13/85671813.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Sai Kung Town"
+    ],
     "name:ceb_x_preferred":[
         "Sai Kung"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:epo_x_preferred":[
         "Sai Kung"
+    ],
+    "name:fas_x_preferred":[
+        "\u0633\u0627\u06cc \u06a9\u0648\u0646\u06af"
     ],
     "name:fra_x_preferred":[
         "Sai Kung"
@@ -230,7 +236,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496704,
+    "wof:lastmodified":1690930172,
     "wof:name":"Sai Kung",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/17/85671817.geojson
+++ b/data/856/718/17/85671817.geojson
@@ -31,7 +31,13 @@
     "name:ara_x_preferred":[
         "\u0645\u0642\u0627\u0637\u0639\u0629 \u0634\u0627 \u062a\u064a\u0646"
     ],
+    "name:bel_x_preferred":[
+        "\u0421\u0430\u0442\u0445\u0456\u043d\u044c"
+    ],
     "name:ceb_x_preferred":[
+        "Sha Tin"
+    ],
+    "name:dan_x_preferred":[
         "Sha Tin"
     ],
     "name:deu_x_preferred":[
@@ -48,6 +54,9 @@
     ],
     "name:eus_x_preferred":[
         "Sha Tin barrutia"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0627 \u062a\u06cc\u0646"
     ],
     "name:fra_x_preferred":[
         "Sha Tin"
@@ -106,6 +115,9 @@
     "name:swe_x_preferred":[
         "Shatian"
     ],
+    "name:swe_x_variant":[
+        "Sha Tin"
+    ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bbe \u0b9f\u0bbf\u0ba9\u0bcd \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
     ],
@@ -114,6 +126,9 @@
     ],
     "name:urd_x_variant":[
         "\u0634\u0627 \u062a\u0646 \u0636\u0644\u0639"
+    ],
+    "name:uzb_x_preferred":[
+        "Shatin"
     ],
     "name:vie_x_preferred":[
         "Sa \u0110i\u1ec1n"
@@ -266,7 +281,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496702,
+    "wof:lastmodified":1690930171,
     "wof:name":"Sha Tin",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/31/85671831.geojson
+++ b/data/856/718/31/85671831.geojson
@@ -31,6 +31,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0642\u0627\u0637\u0639\u0629 \u062a\u0648\u064a\u0646 \u0645\u0648\u0646"
     ],
+    "name:cat_x_preferred":[
+        "Tuen Mun"
+    ],
     "name:ceb_x_preferred":[
         "Tuen Mun"
     ],
@@ -58,6 +61,9 @@
     "name:heb_x_preferred":[
         "\u05d8\u05d5\u05d0\u05df \u05de\u05d0\u05df"
     ],
+    "name:heb_x_variant":[
+        "\u05d8\u05d0\u05d5\u05df \u05de\u05d0\u05df"
+    ],
     "name:ind_x_preferred":[
         "Tuen Mun"
     ],
@@ -82,6 +88,9 @@
     ],
     "name:pan_x_preferred":[
         "\u0a24\u0a41\u0a70\u0a2e\u0a42\u0a28"
+    ],
+    "name:por_x_preferred":[
+        "Tuen Mun"
     ],
     "name:rus_x_preferred":[
         "\u0422\u0445\u044e\u043d\u044c\u043c\u0443\u043d\u044c"
@@ -243,7 +252,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496703,
+    "wof:lastmodified":1690930172,
     "wof:name":"Tuen Mun",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/43/85671843.geojson
+++ b/data/856/718/43/85671843.geojson
@@ -37,6 +37,9 @@
     "name:fra_x_preferred":[
         "Tai Po"
     ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d0\u05d9 \u05e4\u05d5"
+    ],
     "name:kor_x_preferred":[
         "\ud0c0\uc774 \ud3ec"
     ],
@@ -219,7 +222,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496703,
+    "wof:lastmodified":1690930171,
     "wof:name":"Tai Po",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/890/434/547/890434547.geojson
+++ b/data/890/434/547/890434547.geojson
@@ -18,7 +18,13 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
+    "name:afr_x_preferred":[
+        "Kowloon"
+    ],
     "name:ara_x_preferred":[
+        "\u0643\u0648\u0644\u0648\u0646"
+    ],
+    "name:arz_x_preferred":[
         "\u0643\u0648\u0644\u0648\u0646"
     ],
     "name:ast_x_preferred":[
@@ -33,8 +39,17 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0426\u0437\u044e\u043b\u0443\u043d"
     ],
+    "name:bel_x_variant":[
+        "\u0426\u0437\u044e\u043b\u0443\u043d"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09cb\u09b2\u09c1\u09a8"
+    ],
+    "name:ben_x_variant":[
+        "\u0995\u09be\u0989\u09b2\u09c1\u09a8"
+    ],
+    "name:bul_x_preferred":[
+        "\u041a\u043e\u0443\u043b\u0443\u043d"
     ],
     "name:cat_x_preferred":[
         "Kowloon"
@@ -90,6 +105,9 @@
     "name:hun_x_preferred":[
         "Kaulung"
     ],
+    "name:hye_x_preferred":[
+        "\u053f\u0578\u0578\u0582\u056c\u0578\u0582\u0576"
+    ],
     "name:ind_x_preferred":[
         "Kowloon"
     ],
@@ -114,6 +132,9 @@
     "name:kor_x_variant":[
         "\uac00\uc6b0\ub8fd"
     ],
+    "name:lat_x_preferred":[
+        "Novendracones"
+    ],
     "name:lav_x_preferred":[
         "Kauluna"
     ],
@@ -125,6 +146,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0915\u0949\u0935\u094d\u0932\u0942\u0928"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041a\u043e\u0443\u043b\u0443\u043d"
     ],
     "name:msa_x_preferred":[
         "Kowloon"
@@ -192,6 +216,12 @@
     "name:urd_x_preferred":[
         "\u06a9\u0648\u0644\u0648\u0646"
     ],
+    "name:uzb_x_preferred":[
+        "Szyulun"
+    ],
+    "name:war_x_preferred":[
+        "Kowloon"
+    ],
     "name:wuu_x_preferred":[
         "\u4e5d\u9f99"
     ],
@@ -237,7 +267,7 @@
         }
     ],
     "wof:id":890434547,
-    "wof:lastmodified":1566644536,
+    "wof:lastmodified":1690930183,
     "wof:name":"Kowloon",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/437/279/890437279.geojson
+++ b/data/890/437/279/890437279.geojson
@@ -33,6 +33,9 @@
     "name:arz_x_preferred":[
         "\u0647\u0648\u0646\u062c \u0643\u0648\u0646\u062c"
     ],
+    "name:arz_x_variant":[
+        "\u0645\u062f\u064a\u0646\u0629 \u0641\u0643\u062a\u0648\u0631\u064a\u0627"
+    ],
     "name:asm_x_preferred":[
         "\u09b9\u0982\u0995\u0982"
     ],
@@ -59,6 +62,9 @@
     ],
     "name:bul_x_preferred":[
         "\u0425\u043e\u043d\u043a\u043e\u043d\u0433"
+    ],
+    "name:cat_x_preferred":[
+        "Victoria"
     ],
     "name:cdo_x_preferred":[
         "Hi\u014fng-g\u0113\u0324ng"
@@ -113,6 +119,9 @@
     ],
     "name:gan_x_preferred":[
         "\u9999\u6e2f"
+    ],
+    "name:gle_x_preferred":[
+        "Victoria"
     ],
     "name:guj_x_preferred":[
         "\u0ab9\u0acb\u0a82\u0a97\u0a95\u0acb\u0a82\u0a97"
@@ -177,6 +186,9 @@
     "name:mal_x_preferred":[
         "\u0d39\u0d4b\u0d19\u0d4d\u0d15\u0d4b\u0d19\u0d4d"
     ],
+    "name:mal_x_variant":[
+        "\u0d35\u0d3f\u0d15\u0d4d\u0d1f\u0d4b\u0d31\u0d3f\u0d2f"
+    ],
     "name:mar_x_preferred":[
         "\u0939\u093e\u0901\u0917 \u0915\u093e\u0901\u0917"
     ],
@@ -203,6 +215,9 @@
     ],
     "name:nld_x_preferred":[
         "Victoria City"
+    ],
+    "name:nob_x_preferred":[
+        "Victoria"
     ],
     "name:nor_x_preferred":[
         "Hongkong"
@@ -303,6 +318,9 @@
     ],
     "name:vie_x_preferred":[
         "H\u1ed3ng K\u00f4ng"
+    ],
+    "name:vie_x_variant":[
+        "Victoria"
     ],
     "name:wuu_x_preferred":[
         "\u9999\u6e2f"
@@ -457,7 +475,7 @@
         }
     ],
     "wof:id":890437279,
-    "wof:lastmodified":1617130934,
+    "wof:lastmodified":1690930183,
     "wof:megacity":1,
     "wof:name":"Hong Kong",
     "wof:parent_id":85671775,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.