### PR TITLE
hk concordances, placetype local, and more

### DIFF
--- a/data/115/939/722/9/1159397229.geojson
+++ b/data/115/939/722/9/1159397229.geojson
@@ -167,7 +167,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1694639825,
+    "wof:lastmodified":1695884144,
     "wof:name":"New Territories",
     "wof:parent_id":85632483,
     "wof:placetype":"macroregion",

--- a/data/115/939/723/1/1159397231.geojson
+++ b/data/115/939/723/1/1159397231.geojson
@@ -209,7 +209,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1694639825,
+    "wof:lastmodified":1695884144,
     "wof:name":"Kowloon",
     "wof:parent_id":85632483,
     "wof:placetype":"macroregion",

--- a/data/115/939/723/3/1159397233.geojson
+++ b/data/115/939/723/3/1159397233.geojson
@@ -200,7 +200,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1694639828,
+    "wof:lastmodified":1695884161,
     "wof:name":"Hong Kong Island",
     "wof:parent_id":85632483,
     "wof:placetype":"macroregion",

--- a/data/421/171/633/421171633.geojson
+++ b/data/421/171/633/421171633.geojson
@@ -154,7 +154,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884286,
     "wof:name":"Islands",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/421/175/527/421175527.geojson
+++ b/data/421/175/527/421175527.geojson
@@ -78,7 +78,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1694493126,
+    "wof:lastmodified":1695884283,
     "wof:name":"New Territories",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/421/199/281/421199281.geojson
+++ b/data/421/199/281/421199281.geojson
@@ -78,7 +78,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1694493126,
+    "wof:lastmodified":1695884283,
     "wof:name":"Hong Kong Island",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/324/83/85632483.geojson
+++ b/data/856/324/83/85632483.geojson
@@ -1070,6 +1070,7 @@
         "hasc:id":"HK",
         "icao:code":"B-H",
         "ioc:id":"HKG",
+        "iso:code":"HK",
         "iso:id":"CN-HK",
         "itu:id":"HKG",
         "m49:code":"344",
@@ -1080,6 +1081,7 @@
         "wd:id":"Q8646",
         "wmo:id":"HK"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:parent_id",
         "wof:hierarchy"
@@ -1112,7 +1114,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1694639519,
+    "wof:lastmodified":1695881174,
     "wof:name":"Hong Kong S.A.R.",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/717/75/85671775.geojson
+++ b/data/856/717/75/85671775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001731,
-    "geom:area_square_m":19803797.416254,
+    "geom:area_square_m":19803797.416335,
     "geom:bbox":"114.10987,22.25208,114.1682,22.2976",
     "geom:latitude":22.280406,
     "geom:longitude":114.14112,
@@ -259,11 +259,12 @@
         "qs_pg:id":223959,
         "wd:id":"Q312485"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"806babb83ff1f58214a342f9f167b875",
+    "wof:geomhash":"66db4703f40eda07818a427d13f88a93",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -281,7 +282,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1690930170,
+    "wof:lastmodified":1695884846,
     "wof:name":"Central and Western",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/717/79/85671779.geojson
+++ b/data/856/717/79/85671779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001082,
-    "geom:area_square_m":12376707.681285,
+    "geom:area_square_m":12376707.681292,
     "geom:bbox":"114.16316,22.25404,114.20717,22.29387",
     "geom:latitude":22.272112,
     "geom:longitude":114.182394,
@@ -230,11 +230,12 @@
         "qs_pg:id":1137245,
         "wd:id":"Q281527"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e956a946c914d25088fa48fa20d94a09",
+    "wof:geomhash":"517d48d494dda79791567c60f5f54883",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -252,7 +253,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1690930170,
+    "wof:lastmodified":1695884846,
     "wof:name":"Wan Chai",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/717/85/85671785.geojson
+++ b/data/856/717/85/85671785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002287,
-    "geom:area_square_m":26164408.029943,
+    "geom:area_square_m":26164408.029856,
     "geom:bbox":"114.18633,22.24573,114.2616,22.30028",
     "geom:latitude":22.273891,
     "geom:longitude":114.225905,
@@ -173,11 +173,12 @@
         "hasc:id":"HK.EA",
         "qs_pg:id":1263471
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d92e6bda7d4a4d2d8de171693d82c274",
+    "wof:geomhash":"dfc1e7d24fc149e2e422a53a8007ed04",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -195,7 +196,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496701,
+    "wof:lastmodified":1695884846,
     "wof:name":"Eastern",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/717/89/85671789.geojson
+++ b/data/856/717/89/85671789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008235,
-    "geom:area_square_m":94257703.622989,
+    "geom:area_square_m":94257703.622992,
     "geom:bbox":"114.11011,22.19264,114.30907,22.2756",
     "geom:latitude":22.227959,
     "geom:longitude":114.212005,
@@ -193,11 +193,12 @@
         "hasc:id":"HK.SO",
         "qs_pg:id":1259511
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7cb3bd7d1625b4d6967580bb642769a7",
+    "wof:geomhash":"c21415c7910ab3ef827a659e92ffda2a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -215,7 +216,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496700,
+    "wof:lastmodified":1695884846,
     "wof:name":"Southern",
     "wof:parent_id":1159397233,
     "wof:placetype":"region",

--- a/data/856/717/91/85671791.geojson
+++ b/data/856/717/91/85671791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001004,
-    "geom:area_square_m":11487411.872497,
+    "geom:area_square_m":11487411.872506,
     "geom:bbox":"114.14951,22.28805,114.18686,22.32678",
     "geom:latitude":22.30687,
     "geom:longitude":114.166209,
@@ -180,11 +180,12 @@
         "hasc:id":"HK.YT",
         "qs_pg:id":1263472
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9f6edc62637aa442897475274b7714b4",
+    "wof:geomhash":"c867b32c9df66906e04a3c6162ddca9a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -202,7 +203,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496701,
+    "wof:lastmodified":1695884846,
     "wof:name":"Yau Tsim Mong",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/717/97/85671797.geojson
+++ b/data/856/717/97/85671797.geojson
@@ -233,11 +233,12 @@
         "qs_pg:id":1263473,
         "wd:id":"Q1189342"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a23ef08fc1b3b97f269e34cf4d0cd9aa",
+    "wof:geomhash":"10dfe618f96ce2d93acf0f6f7ba3923d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -255,7 +256,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1690930170,
+    "wof:lastmodified":1695884846,
     "wof:name":"Kowloon City",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/717/99/85671799.geojson
+++ b/data/856/717/99/85671799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000947,
-    "geom:area_square_m":10826649.538023,
+    "geom:area_square_m":10826649.53802,
     "geom:bbox":"114.13033,22.31375,114.17685,22.34862",
     "geom:latitude":22.331892,
     "geom:longitude":114.153466,
@@ -204,11 +204,12 @@
         "qs_pg:id":221557,
         "wd:id":"Q1185317"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"943afc69a892d1eb33ad9630e51350cd",
+    "wof:geomhash":"0ecf1dab683cad7416d6bef03d89a18e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -226,7 +227,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1690930170,
+    "wof:lastmodified":1695884846,
     "wof:name":"Sham Shui Po",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/718/05/85671805.geojson
+++ b/data/856/718/05/85671805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000815,
-    "geom:area_square_m":9326099.269296,
+    "geom:area_square_m":9326099.269319,
     "geom:bbox":"114.17946,22.33043,114.22403,22.35841",
     "geom:latitude":22.344022,
     "geom:longitude":114.204178,
@@ -203,11 +203,12 @@
         "qs_pg:id":1137247,
         "wd:id":"Q2548183"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8c32088ec76aa4d376bca90709e82bc9",
+    "wof:geomhash":"4a0f9d64ff4e5bd843d2ece4388b2927",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -225,7 +226,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1690930171,
+    "wof:lastmodified":1695884846,
     "wof:name":"Wong Tai Sin",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/718/09/85671809.geojson
+++ b/data/856/718/09/85671809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001224,
-    "geom:area_square_m":13999384.107933,
+    "geom:area_square_m":13999384.10792,
     "geom:bbox":"114.20171,22.28229,114.24558,22.33496",
     "geom:latitude":22.312256,
     "geom:longitude":114.225968,
@@ -187,11 +187,12 @@
         "qs_pg:id":1137246,
         "wd:id":"Q1045119"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8097f9a89a61b06edef99cc769a880ca",
+    "wof:geomhash":"4d18de0e3922951d449f8d39629c1471",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -209,7 +210,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1690930171,
+    "wof:lastmodified":1695884847,
     "wof:name":"Kwun Tong",
     "wof:parent_id":1159397231,
     "wof:placetype":"region",

--- a/data/856/718/13/85671813.geojson
+++ b/data/856/718/13/85671813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067171,
-    "geom:area_square_m":768480957.677303,
+    "geom:area_square_m":768480957.677142,
     "geom:bbox":"114.22112,22.14846,114.50247,22.46623",
     "geom:latitude":22.297143,
     "geom:longitude":114.38294,
@@ -214,11 +214,12 @@
         "qs_pg:id":1119647,
         "wd:id":"Q1753151"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"88f65660335607883826d3dd683e8dd6",
+    "wof:geomhash":"8c270b3511d99feaf52ab0b9f4ac917d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -236,7 +237,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1690930172,
+    "wof:lastmodified":1695884847,
     "wof:name":"Sai Kung",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/17/85671817.geojson
+++ b/data/856/718/17/85671817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006513,
-    "geom:area_square_m":74463733.524934,
+    "geom:area_square_m":74463733.524841,
     "geom:bbox":"114.14131,22.34417,114.25444,22.43899",
     "geom:latitude":22.389465,
     "geom:longitude":114.201574,
@@ -259,11 +259,12 @@
         "qs_pg:id":1263483,
         "wd:id":"Q855463"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e2f7b859b5f1763274034f0bfa2007a7",
+    "wof:geomhash":"b4bffa3e8f7ec6b1932335e8e3e963c3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -281,7 +282,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1690930171,
+    "wof:lastmodified":1695884847,
     "wof:name":"Sha Tin",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/23/85671823.geojson
+++ b/data/856/718/23/85671823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004323,
-    "geom:area_square_m":49441696.988747,
+    "geom:area_square_m":49441696.98883,
     "geom:bbox":"114.07243,22.29748,114.14996,22.38452",
     "geom:latitude":22.33631,
     "geom:longitude":114.111301,
@@ -179,11 +179,12 @@
         "hasc:id":"HK.KI",
         "qs_pg:id":221556
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0b0ee9948df09b6e521b21542b96cc1",
+    "wof:geomhash":"50fdc25ca6169963ef4a52fb2d6dbb9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -201,7 +202,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496703,
+    "wof:lastmodified":1695884847,
     "wof:name":"Kwai Tsing",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/27/85671827.geojson
+++ b/data/856/718/27/85671827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007389,
-    "geom:area_square_m":84496119.340271,
+    "geom:area_square_m":84496119.340243,
     "geom:bbox":"113.99458,22.31253,114.16919,22.41755",
     "geom:latitude":22.365445,
     "geom:longitude":114.079256,
@@ -207,11 +207,12 @@
         "qs_pg:id":579451,
         "wd:id":"Q1758914"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d4bfa9670a2c500daa2fadda87155c6d",
+    "wof:geomhash":"206d072fe8e0f5a57771a32c74ff15fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -229,7 +230,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496702,
+    "wof:lastmodified":1695884847,
     "wof:name":"Tsuen Wan",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/31/85671831.geojson
+++ b/data/856/718/31/85671831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016532,
-    "geom:area_square_m":189033211.881576,
+    "geom:area_square_m":189033211.881553,
     "geom:bbox":"113.86587,22.32435,114.0662,22.4334",
     "geom:latitude":22.377324,
     "geom:longitude":113.949857,
@@ -230,11 +230,12 @@
         "qs_pg:id":1119648,
         "wd:id":"Q1758751"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3e416ba36b866db2208c422ac3a45558",
+    "wof:geomhash":"f6037df45b126ffe64b6455660048d8e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -252,7 +253,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1690930172,
+    "wof:lastmodified":1695884847,
     "wof:name":"Tuen Mun",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/33/85671833.geojson
+++ b/data/856/718/33/85671833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016442,
-    "geom:area_square_m":187891295.878013,
+    "geom:area_square_m":187891295.877757,
     "geom:bbox":"113.87423,22.39122,114.1279,22.52317",
     "geom:latitude":22.454064,
     "geom:longitude":114.026625,
@@ -189,11 +189,12 @@
         "hasc:id":"HK.YL",
         "qs_pg:id":1119649
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ec35a4a1afac92cce97deb193942a85c",
+    "wof:geomhash":"d7b43433c9f9e8894d033b93c40055a8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -211,7 +212,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496702,
+    "wof:lastmodified":1695884847,
     "wof:name":"Yuen Long",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/39/85671839.geojson
+++ b/data/856/718/39/85671839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016288,
-    "geom:area_square_m":186042431.075989,
+    "geom:area_square_m":186042431.075638,
     "geom:bbox":"114.07834,22.46568,114.33619,22.56833",
     "geom:latitude":22.521141,
     "geom:longitude":114.212165,
@@ -540,11 +540,12 @@
         "hasc:id":"HK.NO",
         "qs_pg:id":579452
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"72cb0eff5fb8fdcb3b36e63db2711d31",
+    "wof:geomhash":"59fc70fb5a99f2211f4ff4d30052e2ee",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -562,7 +563,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496703,
+    "wof:lastmodified":1695884847,
     "wof:name":"North",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/43/85671843.geojson
+++ b/data/856/718/43/85671843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029965,
-    "geom:area_square_m":342380894.354626,
+    "geom:area_square_m":342380894.354678,
     "geom:bbox":"114.11194,22.3936,114.45606,22.56813",
     "geom:latitude":22.47679,
     "geom:longitude":114.307999,
@@ -200,11 +200,12 @@
         "qs_pg:id":1310095,
         "wd:id":"Q1758870"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2fcfafa473387f8debfc6ffa5fd701d7",
+    "wof:geomhash":"d3cf9a9e038ebbf41f7d6b20d174e514",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -222,7 +223,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1690930171,
+    "wof:lastmodified":1695884847,
     "wof:name":"Tai Po",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",

--- a/data/856/718/47/85671847.geojson
+++ b/data/856/718/47/85671847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058231,
-    "geom:area_square_m":666557132.0728,
+    "geom:area_square_m":666557132.072802,
     "geom:bbox":"113.81723,22.13672,114.30925,22.32463",
     "geom:latitude":22.222233,
     "geom:longitude":114.018821,
@@ -182,11 +182,12 @@
         "hasc:id":"HK.IS",
         "qs_pg:id":223958
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a49ce876f2cacacf877c848892a2ab41",
+    "wof:geomhash":"7e87ebe4d25603463af886fd678399d3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -204,7 +205,7 @@
         "zho",
         "eng"
     ],
-    "wof:lastmodified":1636496704,
+    "wof:lastmodified":1695884847,
     "wof:name":"Islands",
     "wof:parent_id":1159397229,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.